### PR TITLE
embed aoestats.io

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -60,6 +60,7 @@ import PushPage from "./src/view/push.page";
 import SplashPage from "./src/view/splash.page";
 import ErrorSnackbar from "./src/view/components/snackbar/error-snackbar";
 import ErrorPage from "./src/view/error.page";
+import WinratesPage from "./src/view/winrates.page";
 import * as Notifications from "expo-notifications";
 import TipsPage from "./src/view/tips.page";
 import {setSavedNotification} from "./src/helper/notification";
@@ -143,6 +144,9 @@ const linking: LinkingOptions = {
             Tech: {
                 path: 'tech/:tech',
             },
+            Winrates: {
+                path: 'winrates',
+            },
         },
     },
 };
@@ -159,6 +163,7 @@ export type RootStackParamList = {
     Changelog: { changelogLastVersionRead?: string };
     Settings: undefined;
     Main: undefined;
+    Winrates: undefined;
     Feed: { action?: string };
     Leaderboard: undefined;
     Civ: { civ: Civ };
@@ -188,6 +193,16 @@ function LinkTitle(props: any) {
         </TouchableOpacity>
     );
 }
+
+function LinkWinratesTitle(props: any) {
+    const appStyles = useTheme(appVariants);
+    return (
+        <TouchableOpacity onPress={() => Linking.openURL('https://aoestats.io')}>
+            <MyText style={appStyles.link}>aoestats.io</MyText>
+        </TouchableOpacity>
+    );
+}
+
 
 // function cacheImages(images: (string | number)[]) {
 //     return images.map(image => {
@@ -403,6 +418,14 @@ export function InnerApp() {
                     component={PrivacyPage}
                     options={{
                         title: 'Privacy',
+                    }}
+                />
+                <Stack.Screen
+                    name="Winrates"
+                    component={WinratesPage}
+                    options={{
+                        animationEnabled: false,
+                        headerTitle: props => <LinkWinratesTitle {...props} />,
                     }}
                 />
             </Stack.Navigator>

--- a/app/src/view/components/footer.tsx
+++ b/app/src/view/components/footer.tsx
@@ -146,6 +146,7 @@ export default function Footer() {
                         <Menu.Item icon={useIcon('archway', 'Building')} titleStyle={iconPopupStyle('Building')} onPress={() => { nav('Building'); setMenu(false); }} title="Buildings" />
                         <Menu.Item icon={useIcon('flask', 'Tech')} titleStyle={iconPopupStyle('Tech')} onPress={() => { nav('Tech'); setMenu(false); }} title="Techs" />
                         <Menu.Item icon={useIcon('fist-raised', 'Unit')} titleStyle={iconPopupStyle('Unit')} onPress={() => { nav('Unit'); setMenu(false); }} title="Units" />
+                        <Menu.Item icon={useIcon('trophy', 'Winrates')} titleStyle={iconPopupStyle('About')} onPress={() => { nav('Winrates'); setMenu(false); }} title="Winrates" />
                     </Menu>
                 </View>
             </View>

--- a/app/src/view/winrates.page.tsx
+++ b/app/src/view/winrates.page.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { WebView } from 'react-native-webview';
+import { Platform, View } from 'react-native';
+
+export default function WinratesPage() {
+    if (Platform.OS === 'web') {
+        return (
+            <iframe
+                style={{ border: 'none' }}
+                height="100%"
+                src="https://aoestats.io/">
+            </iframe>
+        );
+    }
+
+    const [width, setWidth] = useState(300);
+    const [height, setHeight] = useState(400);
+
+    return (
+        <View
+            style={{ minHeight: 300, flex: 1, overflow: 'hidden' }}
+            onLayout={({ nativeEvent: { layout } }: any) => {
+                console.log('layout', layout);
+                setWidth(layout.width);
+                setHeight(layout.height);
+            }}
+        >
+            <WebView
+                allowUniversalAccessFromFileURLs
+                mixedContentMode="always"
+                originWhitelist={['*']}
+
+                source={{ uri: 'https://aoestats.io/' }}
+                scalesPageToFit={false}
+                style={{
+                    minHeight: 200,
+                    backgroundColor: 'grey',
+                    width: width,
+                    height: height,
+                    borderWidth: 1,
+                    borderColor: 'transparent'
+                }}
+                onShouldStartLoadWithRequest={event => {
+                    console.log('onShouldStartLoadWithRequest', event);
+                    return true;
+                }}
+            />
+        </View>
+    );
+}

--- a/app/src/view/winrates.page.tsx
+++ b/app/src/view/winrates.page.tsx
@@ -16,6 +16,11 @@ export default function WinratesPage() {
     const [width, setWidth] = useState(300);
     const [height, setHeight] = useState(400);
 
+    const runFirst = `
+      document.querySelector("div>a.BuyMeACoffe-module--bmc-button--3AWbh").remove();
+      true; // note: this is required, or you'll sometimes get silent failures
+    `;
+
     return (
         <View
             style={{ minHeight: 300, flex: 1, overflow: 'hidden' }}
@@ -29,7 +34,8 @@ export default function WinratesPage() {
                 allowUniversalAccessFromFileURLs
                 mixedContentMode="always"
                 originWhitelist={['*']}
-
+                javaScriptEnabled
+                injectedJavaScript={runFirst}
                 source={{ uri: 'https://aoestats.io/' }}
                 scalesPageToFit={false}
                 style={{


### PR DESCRIPTION
Issue #24 

- Add a menu option 'Winrates'
- Embed aoestats.io in a similar way as buildorderguide.com.
- Remove the 'Buy me a Coffee' button for the mobile platforms

![Screenshot_1601600807](https://user-images.githubusercontent.com/9157911/94878122-1d2fc080-0422-11eb-822b-36aad98a3cf7.png)

![Screenshot_1601600838](https://user-images.githubusercontent.com/9157911/94878142-2ae54600-0422-11eb-9ec9-dca3265931cd.png)


