### PR TITLE
Correction of country.tw in en.json

### DIFF
--- a/app/assets/translations/en.json
+++ b/app/assets/translations/en.json
@@ -680,7 +680,7 @@
   "country.tr": "Turkey",
   "country.tt": "Trinidad and Tobago",
   "country.tv": "Tuvalu",
-  "country.tw": "Taiwan, Province of China",
+  "country.tw": "Taiwan",
   "country.tz": "Tanzania, United Republic of",
   "country.ua": "Ukraine",
   "country.ug": "Uganda",


### PR DESCRIPTION
Changed
"Taiwan, Province of China"
to
"Taiwan"

Because Taiwan is simply not China.