### PR TITLE
Add missing translations

### DIFF
--- a/app/assets/translations/en.json
+++ b/app/assets/translations/en.json
@@ -10,6 +10,12 @@
   "home.followedPlayers": "Followed Players",
   "home.findPlayer": "Find Player",
 
+  "home.current": "Current",
+  "home.mostRecent": "Most Recent",
+  "home.favoriteBuildOrders": "Favorite Build Orders",
+  "home.featuredTournaments": "Featured Tournaments",
+  "home.viewAll": "View All",
+
   "matches.findPlayer": "Find Player",
 
   "main.title": "Me",
@@ -245,6 +251,14 @@
   "lobbies.datausagewarning": "Only use with WiFi.",
   "lobbies.datausagewarning2": "Only use with WiFi. Data usage: {usage} MB",
 
+  "competitive.activeGames.title": "Active Competitive Games",
+  "competitive.activeGames.empty": "No active games.",
+
+  "competitive.upcomingMatches.title": "Upcoming Tournament Matches",
+  "competitive.upcomingMatches.empty": "No upcoming matches right now. Check back later!",
+
+  "competitive.twitchStream.title": "Twitch Stream - {user}",
+
   "ongoing.title": "Ongoing Matches",
   "ongoing.description": "View live matches from the players you follow! Click on a row to show player list.",
   "ongoing.emptydescription": "There are currently no live matches from your followed players. Follow some more players or check back soon!",
@@ -268,6 +282,10 @@
   "search.show": "Show",
   "search.heading.name": "Name",
   "search.heading.games": "Games",
+
+  "search.findmyaccount.title": "Find My Account",
+  "search.findmyaccount.description": "Enter your AoE username to track your games",
+  "search.findmyaccount.action": "Choose",
 
   "privacy.title": "Privacy",
 
@@ -416,6 +434,10 @@
   "feed.following.yplayingnow": "playing now",
 
   "match.versus": "VS",
+  "match.gameMode": "Game Mode",
+  "match.teamSettings": "Team Settings",
+  "match.lockTeams": "Lock Teams",
+  "match.teamTogether": "Team Together",
 
   "playerlist.heading.name": "Name",
   "playerlist.heading.games": "Games",
@@ -472,6 +494,10 @@
   "tournaments.showmatch": "Showmatch",
   "tournaments.results": "Results",
   "tournaments.fullschedule": "Full Schedule",
+  "tournaments.schedulenotavailable": "Schedule not available",
+
+  "notfound.title": "Not Found",
+  "notfound.home": "Go Home",
 
   "checkbox.active": "Active",
   "checkbox.inactive": "Inactive",

--- a/app/src/app/[...unmatched].tsx
+++ b/app/src/app/[...unmatched].tsx
@@ -2,13 +2,17 @@ import { Button } from '@app/components/button';
 import { Header } from '@app/components/header';
 import { Stack } from 'expo-router';
 import { View } from 'react-native';
+import { useTranslation } from '@app/helper/translate';
 
 export default function Unmatched() {
+    const getTranslation = useTranslation();
     return (
         <View className="flex-1 items-center justify-center">
-            <Stack.Screen options={{ title: 'Not Found', headerShown: true, header: Header }} />
+            <Stack.Screen
+                options={{ title: getTranslation('notfound.title'), headerShown: true, header: Header }}
+            />
 
-            <Button href="/">Go Home</Button>
+            <Button href="/">{getTranslation('notfound.home')}</Button>
         </View>
     );
 }

--- a/app/src/app/competitive/games.tsx
+++ b/app/src/app/competitive/games.tsx
@@ -10,20 +10,28 @@ import compact from 'lodash/compact';
 import groupBy from 'lodash/groupBy';
 import React, { Fragment } from 'react';
 import { View } from 'react-native';
+import { useTranslation } from '@app/helper/translate';
 
 export default function OngoingMatchesPage() {
+    const getTranslation = useTranslation();
     const { matches, isLoading } = useOngoing({ verified: true });
 
     return (
         <>
-            <Stack.Screen options={{ title: 'Active Competitive Games' }} />
+            <Stack.Screen
+                options={{ title: getTranslation('competitive.activeGames.title') }}
+            />
 
             <FlatList
                 refreshControl={<RefreshControlThemed refreshing={isLoading} />}
                 refreshing={isLoading}
                 className="flex-1"
                 contentContainerStyle="p-4 gap-2"
-                ListEmptyComponent={isLoading ? null : <Text>No active games.</Text>}
+                ListEmptyComponent={
+                    isLoading ? null : (
+                        <Text>{getTranslation('competitive.activeGames.empty')}</Text>
+                    )
+                }
                 data={matches}
                 renderItem={({ item: match }) => {
                     const highlightedUsers = match.players.filter(p => p.verified).map(p => p.profileId);

--- a/app/src/app/competitive/index.tsx
+++ b/app/src/app/competitive/index.tsx
@@ -24,8 +24,10 @@ import compact from 'lodash/compact';
 import { useCallback, useEffect, useState } from 'react';
 import { Platform, TouchableOpacity, View } from 'react-native';
 import WebView from 'react-native-webview';
+import { useTranslation } from '@app/helper/translate';
 
 export default function Competitive() {
+    const getTranslation = useTranslation();
     const [isVideoPlaying, setIsVideoPlaying] = useState(false);
     const { matches } = useOngoing({ verified: true });
     const { data: tournamentMatches, isLoading: isLoadingUpcomingMatches } = useTournamentMatches();
@@ -165,8 +167,12 @@ export default function Competitive() {
                 {tournamentsEnabled && (
                     <View className="gap-2">
                         <View className="flex-row justify-between items-center px-4">
-                            <Text variant="header-lg">Featured Tournaments</Text>
-                            <Link href="/competitive/tournaments">View All</Link>
+                        <Text variant="header-lg">
+                            {getTranslation('home.featuredTournaments')}
+                        </Text>
+                            <Link href="/competitive/tournaments">
+                                {getTranslation('home.viewAll')}
+                            </Link>
                         </View>
 
                         <FlatList
@@ -186,7 +192,7 @@ export default function Competitive() {
                 {tournamentsEnabled && (
                     <View className="gap-2">
                         <Text className="px-4" variant="header-lg">
-                            Upcoming Tournament Matches
+                            {getTranslation('competitive.upcomingMatches.title')}
                         </Text>
 
                         <FlatList
@@ -207,7 +213,13 @@ export default function Competitive() {
                             contentContainerStyle="gap-2.5 px-4"
                             horizontal
                             showsHorizontalScrollIndicator={false}
-                            ListEmptyComponent={<Text>No upcoming matches right now. Check back later!</Text>}
+                            ListEmptyComponent={
+                                <Text>
+                                    {getTranslation(
+                                        'competitive.upcomingMatches.empty'
+                                    )}
+                                </Text>
+                            }
                         />
                     </View>
                 )}
@@ -215,7 +227,11 @@ export default function Competitive() {
                 {liveTwitch && (
                     <View className="px-4 gap-3">
                         <View className="flex-row justify-between items-center">
-                            <Text variant="header-lg">Twitch Stream - {liveTwitch.user_name}</Text>
+                            <Text variant="header-lg">
+                                {getTranslation('competitive.twitchStream.title', {
+                                    user: liveTwitch.user_name,
+                                })}
+                            </Text>
                             <Tag leftComponent={<View className="w-2 h-2 rounded-full bg-red-600" />}>{liveTwitch.viewer_count.toString()}</Tag>
                         </View>
 

--- a/app/src/app/competitive/tournaments/[id].tsx
+++ b/app/src/app/competitive/tournaments/[id].tsx
@@ -390,7 +390,9 @@ export default function TournamentDetail() {
                     </View>,
                     <View className="gap-2 px-4">
                         <Text variant="header">{getTranslation('tournaments.fullschedule')}</Text>
-                        {!tournament.scheduleNote && tournament.schedule.length === 0 ? <Text>Schedule not available</Text> : null}
+                        {!tournament.scheduleNote && tournament.schedule.length === 0 ? (
+                            <Text>{getTranslation('tournaments.schedulenotavailable')}</Text>
+                        ) : null}
 
                         {tournament.scheduleNote && (
                             <View className="pb-4">

--- a/app/src/app/competitive/tournaments/index.tsx
+++ b/app/src/app/competitive/tournaments/index.tsx
@@ -100,7 +100,7 @@ export default function TournamentsList() {
                     title: getTranslation('tournaments.title'),
                     headerRight: () => (
                         <Button size="small" href="/competitive/tournaments/all">
-                            View All
+                            {getTranslation('home.viewAll')}
                         </Button>
                     ),
                 }}

--- a/app/src/app/explore/index.tsx
+++ b/app/src/app/explore/index.tsx
@@ -155,7 +155,9 @@ export default function Explore() {
                         <View className="gap-2">
                             <View className="flex-row justify-between items-center px-4">
                                 <Text variant="header-lg">Civilizations</Text>
-                                <Link href="/explore/civilizations">View All</Link>
+                                <Link href="/explore/civilizations">
+                                    {getTranslation('home.viewAll')}
+                                </Link>
                             </View>
 
                             <FlatList
@@ -181,7 +183,9 @@ export default function Explore() {
                         <View className="gap-2">
                             <View className="flex-row justify-between items-center px-4">
                                 <Text variant="header-lg">Units</Text>
-                                <Link href="/explore/units">View All</Link>
+                                <Link href="/explore/units">
+                                    {getTranslation('home.viewAll')}
+                                </Link>
                             </View>
 
                             <FlatList
@@ -211,7 +215,9 @@ export default function Explore() {
                         <View className="gap-2">
                             <View className="flex-row justify-between items-center px-4">
                                 <Text variant="header-lg">Buildings</Text>
-                                <Link href="/explore/buildings">View All</Link>
+                                <Link href="/explore/buildings">
+                                    {getTranslation('home.viewAll')}
+                                </Link>
                             </View>
 
                             <FlatList
@@ -241,7 +247,9 @@ export default function Explore() {
                         <View className="gap-2">
                             <View className="flex-row justify-between items-center px-4">
                                 <Text variant="header-lg">Technologies</Text>
-                                <Link href="/explore/technologies">View All</Link>
+                                <Link href="/explore/technologies">
+                                    {getTranslation('home.viewAll')}
+                                </Link>
                             </View>
 
                             <FlatList
@@ -275,7 +283,9 @@ export default function Explore() {
                         <View className="gap-2">
                             <View className="flex-row justify-between items-center px-4">
                                 <Text variant="header-lg">Build Orders</Text>
-                                <Link href="/explore/build-orders">View All</Link>
+                                <Link href="/explore/build-orders">
+                                    {getTranslation('home.viewAll')}
+                                </Link>
                             </View>
 
                             <FlatList

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -144,7 +144,14 @@ export default function IndexPage() {
 
             {authProfileId && (
                 <View className="gap-2">
-                    <Text variant="header-lg">{currentMatch?.finished === null ? 'Current' : 'Most Recent'} Match</Text>
+                    <Text variant="header-lg">
+                        {getTranslation(
+                            currentMatch?.finished === null
+                                ? 'home.current'
+                                : 'home.mostRecent'
+                        )}{' '}
+                        Match
+                    </Text>
 
                     <View className="gap-2">
                         <Match user={currentMatch?.filteredPlayers[0]} highlightedUsers={currentMatch?.filteredPlayers} match={currentMatch} />
@@ -155,8 +162,12 @@ export default function IndexPage() {
             {favorites.length > 0 && (
                 <View className="gap-2">
                     <View className="flex-row justify-between items-center">
-                        <Text variant="header-lg">Favorite Build Orders</Text>
-                        <Link href="/explore/build-orders">View All</Link>
+                        <Text variant="header-lg">
+                            {getTranslation('home.favoriteBuildOrders')}
+                        </Text>
+                        <Link href="/explore/build-orders">
+                            {getTranslation('home.viewAll')}
+                        </Link>
                     </View>
 
                     <FlatList
@@ -176,7 +187,9 @@ export default function IndexPage() {
                 <View className="gap-2">
                     <View className="flex-row justify-between items-center">
                         <Text variant="header-lg">{followedIds[0] ? 'Favorite' : 'Featured'} Tournament</Text>
-                        <Link href="/competitive/tournaments">View All</Link>
+                        <Link href="/competitive/tournaments">
+                            {getTranslation('home.viewAll')}
+                        </Link>
                     </View>
                     {followedIds[0] ? <TournamentCardLarge path={followedIds[0]} /> : <TournamentCardLarge {...tournament} />}
                 </View>

--- a/app/src/app/matches/single/[matchId].tsx
+++ b/app/src/app/matches/single/[matchId].tsx
@@ -174,15 +174,17 @@ export default function MatchPage() {
                 {/*<FontAwesome name={'check-square'} size={14} color={theme.textNoteColor} />*/}
 
                 <View className="flex-col gap-1">
-                    <Text>Game Mode: {match.gameModeName}</Text>
-                    <Text>Team Settings</Text>
+                    <Text>
+                        {getTranslation('match.gameMode')}: {match.gameModeName}
+                    </Text>
+                    <Text>{getTranslation('match.teamSettings')}</Text>
                     <View className="flex-row items-center gap-1">
                         <FontAwesome5 name={match.lockTeams ? 'check-square' : 'square'} size={14} color={theme.textNoteColor} />
-                        <Text>Lock Teams</Text>
+                        <Text>{getTranslation('match.lockTeams')}</Text>
                     </View>
                     <View className="flex-row items-center gap-1">
                         <FontAwesome5 name={match.teamTogether ? 'check-square' : 'square'} size={14} color={theme.textNoteColor} />
-                        <Text>Team Together</Text>
+                        <Text>{getTranslation('match.teamTogether')}</Text>
                     </View>
                 </View>
 

--- a/app/src/app/matches/users/select.tsx
+++ b/app/src/app/matches/users/select.tsx
@@ -1,6 +1,7 @@
 import Search from '@app/view/components/search';
 import { router, useLocalSearchParams, useNavigation } from 'expo-router';
 import { useEffect } from 'react';
+import { useTranslation } from '@app/helper/translate';
 import { useSaveAccountMutation } from '@app/mutations/save-account';
 import { useAccount } from '@app/queries/all';
 
@@ -12,6 +13,7 @@ const SelectProfilePage = () => {
     const { search } = useLocalSearchParams<ISearchProfilePageParams>();
     const { data: account } = useAccount();
     const saveAccountMutation = useSaveAccountMutation();
+    const getTranslation = useTranslation();
 
     const onSelect = async (user: any) => {
         console.log('SELECTED', user);
@@ -24,11 +26,16 @@ const SelectProfilePage = () => {
     const navigation = useNavigation();
 
     useEffect(() => {
-        navigation.setOptions({ title: 'Find My Account' });
-    }, [navigation]);
+        navigation.setOptions({ title: getTranslation('search.findmyaccount.title') });
+    }, [navigation, getTranslation]);
 
     return (
-        <Search title="Enter your AoE username to track your games" selectedUser={onSelect} actionText="Choose" initialText={search} />
+        <Search
+            title={getTranslation('search.findmyaccount.description')}
+            selectedUser={onSelect}
+            actionText={getTranslation('search.findmyaccount.action')}
+            initialText={search}
+        />
     );
 };
 


### PR DESCRIPTION
## Summary
- add translation hook usage for newly added strings

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('app/assets/translations/en.json','utf8')); console.log('valid')"`
- `yarn lint` *(fails: Request was cancelled)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68590e5987f4832482079e1dec3c66ba