### PR TITLE
Convert Icon string props to imported FA icon definitions

### DIFF
--- a/src/app/(main)/competitive/index.tsx
+++ b/src/app/(main)/competitive/index.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from '@app/helper/translate';
 import { openLinkWithCheck } from '@app/helper/url';
 import { showAlert } from '@app/helper/alert';
 import { Button } from '@app/components/button';
+import { faPlayCircle } from '@fortawesome/sharp-solid-svg-icons';
 import { useBreakpoints } from '@app/hooks/use-breakpoints';
 import { getUnixTime } from 'date-fns';
 
@@ -303,7 +304,7 @@ export default function Competitive() {
                                             style={{ width: '100%', aspectRatio: 800 / 450 }}
                                         />
                                         <View className="absolute top-0 left-0 right-0 bottom-0 items-center justify-center">
-                                            <Icon icon="play-circle" size={40} color="subtle" />
+                                            <Icon icon={faPlayCircle} size={40} color="subtle" />
                                         </View>
                                     </TouchableOpacity>
                                 )}

--- a/src/app/(main)/competitive/tournaments/[id].tsx
+++ b/src/app/(main)/competitive/tournaments/[id].tsx
@@ -34,6 +34,8 @@ import { uniq } from 'lodash';
 import { BottomSheet } from '@app/view/bottom-sheet';
 import { formatCustom } from '@nex/data';
 import { UserLoginWrapper } from '@app/components/user-login-wrapper';
+import { faHeart as faHeartSolid } from '@fortawesome/sharp-solid-svg-icons';
+import { faHeart as faHeartRegular, faInfoCircle } from '@fortawesome/sharp-regular-svg-icons';
 
 export default function TournamentDetail() {
     const getTranslation = useTranslation();
@@ -183,7 +185,7 @@ export default function TournamentDetail() {
                                     <Text variant="header">{getTranslation('tournaments.participants')}</Text>
                                     {tournament.participantsNote && (
                                         <TouchableOpacity onPress={() => setShowParticipantsNote((val) => !val)}>
-                                            <Icon prefix="fasr" icon="info-circle" color="brand" />
+                                            <Icon icon={faInfoCircle} color="brand" />
                                         </TouchableOpacity>
                                     )}
                                 </View>
@@ -255,7 +257,7 @@ export default function TournamentDetail() {
                                     <Text variant="header">Results</Text>
                                     {tournament.format && hasResults ? (
                                         <TouchableOpacity onPress={() => setShowFormatNote((val) => !val)}>
-                                            <Icon prefix="fasr" icon="info-circle" color="brand" />
+                                            <Icon icon={faInfoCircle} color="brand" />
                                         </TouchableOpacity>
                                     ) : null}
                                 </View>
@@ -559,7 +561,7 @@ function HeaderButtons({ id }: { id: string }) {
                 <Image style={{ width: 28, height: 20 }} source={require('../../../../../assets/icon/liquipedia.png')} />
             </TouchableOpacity>
             <UserLoginWrapper Component={TouchableOpacity} hitSlop={10} onPress={toggleFollow}>
-                <Icon prefix={isFollowed ? 'fass' : 'fasr'} icon="heart" size={20} color="accent-[#ef4444]" />
+                <Icon icon={isFollowed ? faHeartSolid : faHeartRegular} size={20} color="accent-[#ef4444]" />
             </UserLoginWrapper>
         </View>
     );

--- a/src/app/(main)/explore/build-orders/[id].tsx
+++ b/src/app/(main)/explore/build-orders/[id].tsx
@@ -23,6 +23,8 @@ import { isValidUrl } from '@app/api/helper/util';
 import { useBuild } from '@app/queries/all';
 import { useFavoritedBuild } from '@app/service/favorite-builds';
 import { UserLoginWrapper } from '@app/components/user-login-wrapper';
+import { faHeart as faHeartSolid } from '@fortawesome/sharp-solid-svg-icons';
+import { faHeart as faHeartRegular } from '@fortawesome/sharp-regular-svg-icons';
 import NotFound from '@app/app/(main)/+not-found';
 import { LoadingScreen } from '@app/components/loading-screen';
 
@@ -54,7 +56,7 @@ export function FavoriteHeaderButton(props: FavoriteHeaderButtonProps) {
 
     return (
         <UserLoginWrapper Component={TouchableOpacity} hitSlop={10} onPress={toggleFavorite}>
-            <Icon prefix={isFavorited ? 'fass' : 'fasr'} icon="heart" size={20} color="accent-[#ef4444]" />
+            <Icon icon={isFavorited ? faHeartSolid : faHeartRegular} size={20} color="accent-[#ef4444]" />
         </UserLoginWrapper>
     );
 }

--- a/src/app/(main)/matches/live/competitive.tsx
+++ b/src/app/(main)/matches/live/competitive.tsx
@@ -9,6 +9,7 @@ import groupBy from 'lodash/groupBy';
 import React, { Fragment } from 'react';
 import { View } from 'react-native';
 import { useTranslation } from '@app/helper/translate';
+import { faPlus } from '@fortawesome/sharp-regular-svg-icons';
 
 export default function OngoingMatchesPage() {
     const getTranslation = useTranslation();
@@ -39,7 +40,7 @@ export default function OngoingMatchesPage() {
                             <View className="flex-row items-center flex-wrap" style={{ columnGap: 8 }}>
                                 {highlightedUsers.map((player, index) => (
                                     <Fragment key={player.profileId.toString()}>
-                                        {index !== 0 && <Icon prefix="fasr" icon="plus" size={10} />}
+                                        {index !== 0 && <Icon icon={faPlus} size={10} />}
                                         <Text variant="label">{player?.name}</Text>
                                     </Fragment>
                                 ))}

--- a/src/app/(main)/matches/live/following.tsx
+++ b/src/app/(main)/matches/live/following.tsx
@@ -14,6 +14,7 @@ import { Icon } from '@app/components/icon';
 import { Card } from '@app/components/card';
 import { Button } from '@app/components/button';
 import { useRedirectUnauthenticated } from '@app/hooks/use-redirect-unauthenticated';
+import { faPlus } from '@fortawesome/sharp-regular-svg-icons';
 
 export default function LiveFollowingPage() {
     useRedirectUnauthenticated();
@@ -74,7 +75,7 @@ export default function LiveFollowingPage() {
                         <View className="flex-row items-center flex-wrap" style={{ columnGap: 8 }}>
                             {highlightedUsers.map((player, index) => (
                                 <Fragment key={player.profileId.toString()}>
-                                    {index !== 0 && <Icon prefix="fasr" icon="plus" size={10} />}
+                                    {index !== 0 && <Icon icon={faPlus} size={10} />}
                                     <Text variant="label">{player?.name}</Text>
                                 </Fragment>
                             ))}
@@ -114,7 +115,7 @@ export default function LiveFollowingPage() {
                         <View className="flex-row items-center flex-wrap" style={{ columnGap: 8 }}>
                             {highlightedUsers.map((player, index) => (
                                 <Fragment key={player.profileId.toString()}>
-                                    {index !== 0 && <Icon prefix="fasr" icon="plus" size={10} />}
+                                    {index !== 0 && <Icon icon={faPlus} size={10} />}
                                     <Text variant="label">{player?.name}</Text>
                                 </Fragment>
                             ))}

--- a/src/app/(main)/more/index.tsx
+++ b/src/app/(main)/more/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '@app/helper/translate';
 import { appConfig } from '@nex/dataset';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { Image } from '@app/components/uniwind/image';
+import { faAngleRight } from '@fortawesome/sharp-solid-svg-icons';
 
 interface Link {
     icon: IconName;
@@ -59,7 +60,7 @@ export default function More() {
                                 <Text variant="header-sm">{title}</Text>
                             </View>
                             <View className="flex-1" />
-                            <Icon icon="angle-right" color="brand" size={20} />
+                            <Icon icon={faAngleRight} color="brand" size={20} />
                         </TouchableOpacity>
                     </Link>
                 )}

--- a/src/app/(main)/players/[profileId]/(tabs)/_layout.tsx
+++ b/src/app/(main)/players/[profileId]/(tabs)/_layout.tsx
@@ -34,7 +34,8 @@ import { Skeleton } from '@app/components/skeleton';
 import {
     TopTabs
 } from 'expo-router/js-top-tabs';
-import { faFamily } from '@fortawesome/sharp-solid-svg-icons';
+import { faCheckCircle, faFamily, faHeart as faHeartSolid, faLink, faUserTimes } from '@fortawesome/sharp-solid-svg-icons';
+import { faHeart as faHeartRegular } from '@fortawesome/sharp-regular-svg-icons';
 
 interface UserMenuProps {
     profile?: IProfilesResultProfile;
@@ -141,8 +142,8 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
                                         >
                                             <Image source={{ uri: linkedProfile.avatarMediumUrl }} className="w-5 h-5 rounded-full" />
                                             <Text variant="body">{linkedProfile.name}</Text>
-                                            {linkedProfile.verified && <Icon icon="check-circle" color="brand" size={14} />}
-                                            {!linkedProfile.verified && linkedProfile.shared && <Icon icon="family" color="brand" size={14} />}
+                                            {linkedProfile.verified && <Icon icon={faCheckCircle} color="brand" size={14} />}
+                                            {!linkedProfile.verified && linkedProfile.shared && <Icon icon={faFamily} color="brand" size={14} />}
                                             {!!linkedProfile.clan && (
                                                 <MyText>
                                                     {' '}
@@ -156,7 +157,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
 
                             {!fullProfile?.verified && fullProfile?.shared && (
                                 <View className="flex-row items-center gap-x-2">
-                                    <Icon icon="family" color="brand" size={14} />
+                                    <Icon icon={faFamily} color="brand" size={14} />
                                     <MyText>{getTranslation('main.profile.steamfamilysharing')}</MyText>
                                 </View>
                             )}
@@ -177,7 +178,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
             {profile.verified &&
                 (Platform.OS === 'web' ? (
                     <Link href={`https://liquipedia.net/ageofempires/${profile.socialLiquipedia}`} target="_blank">
-                        <Icon icon="check-circle" color="brand" size={20} />
+                        <Icon icon={faCheckCircle} color="brand" size={20} />
                     </Link>
                 ) : (
                     <TouchableOpacity
@@ -185,7 +186,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
                         onPress={() => setShowTournamentPlayer(true)}
                         disabled={!liquipediaProfile}
                     >
-                        <Icon icon="check-circle" color="brand" size={20} />
+                        <Icon icon={faCheckCircle} color="brand" size={20} />
                         {/*<FontAwesome5 style={styles.menuIcon} name="check-circle" color="brand" size={20} />*/}
                     </TouchableOpacity>
                 ))}
@@ -202,7 +203,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
                 onDismiss={() => setLinksVisible(false)}
                 anchor={
                     <TouchableOpacity className="w-8 items-center justify-center" onPress={() => setLinksVisible(true)}>
-                        <Icon icon="link" color="brand" size={20} />
+                        <Icon icon={faLink} color="brand" size={20} />
                     </TouchableOpacity>
                 }
             >
@@ -217,7 +218,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
 
             {profileId === authProfileId ? (
                 <TouchableOpacity onPress={showResetOrUnlinkDialog}>
-                    <Icon icon="user-times" size={20} color="subtle" />
+                    <Icon icon={faUserTimes} size={20} color="subtle" />
                 </TouchableOpacity>
             ) : (
                 <UserLoginWrapper
@@ -226,7 +227,7 @@ export function UserMenu({ profile, fullProfile }: UserMenuProps) {
                     hitSlop={10}
                     onPress={followingThisUser ? () => unfollowMutation.mutate([profileId]) : () => followMutation.mutate([profileId])}
                 >
-                    <Icon prefix={followingThisUser ? 'fass' : 'fasr'} icon="heart" size={20} color="accent-[#ef4444]" />
+                    <Icon icon={followingThisUser ? faHeartSolid : faHeartRegular} size={20} color="accent-[#ef4444]" />
                 </UserLoginWrapper>
             )}
         </View>

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { Skeleton } from './skeleton';
 import { Image } from './uniwind/image';
 import { Icon } from './icon';
+import { faArrowRightFromBracket, faArrowRightToBracket, faCog, faUser, faUserCircle } from '@fortawesome/sharp-solid-svg-icons';
 import { Pressable, View } from 'react-native';
 import { useAccount, useProfileFast } from '@app/queries/all';
 import cn from 'classnames';
@@ -34,7 +35,7 @@ export const AccountMenu: React.FC = () => {
                             <Image className="w-10 h-10 rounded-full" source={{ uri: profile?.avatarFullUrl }} />
                         ) : (
                             <View className="w-10 h-10 justify-center items-center">
-                                <Icon icon="user" size={24} />
+                                <Icon icon={faUser} size={24} />
                             </View>
                         )}
                     </MenuButton>
@@ -51,7 +52,7 @@ export const AccountMenu: React.FC = () => {
                                     href={`/players/${account.profileId}`}
                                     className="flex flex-row w-full items-center gap-2 rounded-lg px-3 py-1.5 hover:bg-hoverBackground"
                                 >
-                                    <Icon icon="user" />
+                                    <Icon icon={faUser} />
                                     <Text variant="body-lg">Profile</Text>
                                 </Link>
                             </MenuItem>
@@ -65,7 +66,7 @@ export const AccountMenu: React.FC = () => {
                                         href="/more/account"
                                         className="flex flex-row w-full items-center gap-2 rounded-lg px-3 py-1.5 hover:bg-hoverBackground"
                                     >
-                                        <Icon icon="user-circle" />
+                                        <Icon icon={faUserCircle} />
                                         <Text variant="body-lg">Account</Text>
                                     </Link>
                                 </MenuItem>
@@ -76,7 +77,7 @@ export const AccountMenu: React.FC = () => {
                                         href="/more/settings"
                                         className="flex flex-row w-full items-center gap-2 rounded-lg px-3 py-1.5 hover:bg-hoverBackground"
                                     >
-                                        <Icon icon="cog" />
+                                        <Icon icon={faCog} />
                                         <Text variant="body-lg">Settings</Text>
                                     </Link>
                                 </MenuItem>
@@ -91,7 +92,7 @@ export const AccountMenu: React.FC = () => {
                                         }}
                                         className="flex flex-row w-full items-center gap-2 rounded-lg px-3 py-1.5 hover:bg-hoverBackground"
                                     >
-                                        <Icon icon="arrow-right-from-bracket" />
+                                        <Icon icon={faArrowRightFromBracket} />
                                         Logout
                                     </Pressable>
                                 </MenuItem>
@@ -107,7 +108,7 @@ export const AccountMenu: React.FC = () => {
                                     }}
                                     className="flex flex-row w-full items-center gap-2 rounded-lg px-3 py-1.5 hover:bg-hoverBackground"
                                 >
-                                    <Icon icon="arrow-right-to-bracket" />
+                                    <Icon icon={faArrowRightToBracket} />
                                     Login
                                 </Pressable>
                             </MenuItem>

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -4,6 +4,7 @@ import { Href, useGlobalSearchParams, useLocalSearchParams, useSegments } from '
 import startCase from 'lodash/startCase';
 import { Link } from './link';
 import { Icon } from './icon';
+import { faChevronRight } from '@fortawesome/sharp-solid-svg-icons';
 import { Fragment } from 'react';
 import { SkeletonText } from './skeleton';
 import cn from 'classnames';
@@ -25,7 +26,7 @@ export const Breadcrumbs: React.FC<{ title: string; paramReplacements?: Record<s
             <Link href="/" color="subtle">
                 Home
             </Link>
-            <Icon icon="chevron-right" size={12} />
+            <Icon icon={faChevronRight} size={12} />
 
             {screenNames.map(({ key, value: segment }, index) => {
                 const isLast = index === screenNames.length - 1;
@@ -45,7 +46,7 @@ export const Breadcrumbs: React.FC<{ title: string; paramReplacements?: Record<s
                     return (
                         <Fragment key={fullPath}>
                             <SkeletonText className="w-10!" />
-                            <Icon icon="chevron-right" size={12} color="subtle" />
+                            <Icon icon={faChevronRight} size={12} color="subtle" />
                         </Fragment>
                     )
                 }
@@ -58,7 +59,7 @@ export const Breadcrumbs: React.FC<{ title: string; paramReplacements?: Record<s
                         >
                             {replacement ?? startCase(segment)}
                         </Link>
-                        <Icon icon="chevron-right" size={12} color="subtle" />
+                        <Icon icon={faChevronRight} size={12} color="subtle" />
                     </Fragment>
                 );
             })}

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -3,6 +3,8 @@ import { MyText } from '@app/view/components/my-text';
 import { GestureResponderEvent, TouchableOpacity, View } from 'react-native';
 import React from 'react';
 import { Icon } from '@app/components/icon';
+import { faSquareCheck } from '@fortawesome/sharp-solid-svg-icons';
+import { faSquare } from '@fortawesome/sharp-regular-svg-icons';
 import { useTranslation } from '@app/helper/translate';
 
 export { IconName, IconPrefix };
@@ -19,8 +21,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({ checked, onPress, text, disa
     return (
         <TouchableOpacity activeOpacity={1} onPress={onPress} disabled={disabled}>
             <View className="flex flex-row items-center gap-2 p-2">
-                {checked && <Icon icon="square-check" color="brand" size={20} />}
-                {!checked && <Icon icon="square" color="brand" prefix="fasr" size={20} />}
+                {checked && <Icon icon={faSquareCheck} color="brand" size={20} />}
+                {!checked && <Icon icon={faSquare} color="brand" size={20} />}
                 <MyText>{text ?? (checked ? getTranslation('checkbox.active') : getTranslation('checkbox.inactive'))}</MyText>
             </View>
         </TouchableOpacity>

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -4,6 +4,8 @@ import { Pressable, View, ViewStyle } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
 import { Icon } from './icon';
+import { faAngleDown as faAngleDownSolid } from '@fortawesome/sharp-solid-svg-icons';
+import { faAngleDown as faAngleDownRegular } from '@fortawesome/sharp-regular-svg-icons';
 import { Text } from './text';
 
 interface Item<ValueType extends string> {
@@ -55,7 +57,7 @@ export const Dropdown = <ValueType extends string>({
                     ))}
                 </View>
 
-                <Icon size={isSmall ? 14 : 16} prefix={isSmall ? 'fasr' : 'fass'} icon="angle-down" />
+                <Icon size={isSmall ? 14 : 16} icon={isSmall ? faAngleDownRegular : faAngleDownSolid} />
             </Pressable>
 
             {isOpen && (

--- a/src/components/field.tsx
+++ b/src/components/field.tsx
@@ -2,6 +2,7 @@ import { textColors } from '@app/utils/text.util';
 import { TextInput, TextInputProps, TouchableOpacity, View, ViewStyle } from 'react-native';
 
 import { Icon } from './icon';
+import { faSearch, faTimesCircle } from '@fortawesome/sharp-solid-svg-icons';
 import { useState } from 'react';
 import cn from 'classnames';
 
@@ -48,7 +49,7 @@ export const Field: React.FC<FieldProps> = ({ type: inputType = 'default', style
         <View className="relative" style={style}>
             {inputType === 'search' ? (
                 <View className="absolute left-3 top-0 h-full justify-center z-10">
-                    <Icon icon="search" color={iconColor ?? 'subtle'} />
+                    <Icon icon={faSearch} color={iconColor ?? 'subtle'} />
                 </View>
             ) : null}
             <TextInput
@@ -62,7 +63,7 @@ export const Field: React.FC<FieldProps> = ({ type: inputType = 'default', style
             />
             {inputType === 'search' && props.value ? (
                 <TouchableOpacity className="absolute right-0 px-3 top-0 h-full justify-center" onPress={() => props.onChangeText?.('')}>
-                    <Icon icon="times-circle" />
+                    <Icon icon={faTimesCircle} />
                 </TouchableOpacity>
             ) : null}
             {inputType === 'password' ? (

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,6 +4,7 @@ import { Platform, TouchableOpacity, View } from 'react-native';
 
 import { HeaderTitle } from './header-title';
 import { Icon } from './icon';
+import { faAngleLeft } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from './text';
 import cn from 'classnames';
 import { containerClassName } from '@app/styles';
@@ -41,7 +42,7 @@ export const Header: React.FC<
                 {back && Platform.OS !== 'web' && (
                     <View>
                         <TouchableOpacity onPress={() => navigation.goBack()} hitSlop={10}>
-                            <Icon icon="angle-left" size={22} color="foreground" />
+                            <Icon icon={faAngleLeft} size={22} color="foreground" />
                         </TouchableOpacity>
                     </View>
                 )}

--- a/src/components/login-modal.tsx
+++ b/src/components/login-modal.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
 import { Icon } from './icon';
+import { faTimes } from '@fortawesome/sharp-regular-svg-icons';
 import { TouchableOpacity, View } from 'react-native';
 import { Text } from './text';
 import Login from './login';
@@ -41,7 +42,7 @@ export const LoginModal = ({ onClose, isVisible }: { isVisible: boolean; onClose
                                 </Text>
 
                                 <TouchableOpacity onPress={onClose} className="absolute top-5 right-5">
-                                    <Icon icon="times" size={32} prefix="fasr" />
+                                    <Icon icon={faTimes} size={32} />
                                 </TouchableOpacity>
 
                                 <Text variant="body-lg" align="center">

--- a/src/components/match/match-card.tsx
+++ b/src/components/match/match-card.tsx
@@ -6,6 +6,7 @@ import React, { Fragment } from 'react';
 import { Platform, Pressable, TouchableOpacity, View } from 'react-native';
 import { Card } from '../card';
 import { Icon } from '../icon';
+import { faBan, faCrown, faEye, faSkull } from '@fortawesome/sharp-solid-svg-icons';
 import { Skeleton, SkeletonText } from '../skeleton';
 import { Text } from '../text';
 import { MatchProps } from '@app/components/match/match';
@@ -78,7 +79,7 @@ export function MatchCard(props: MatchCardProps) {
                         </MapLinkComponent>
                         <View className={`absolute ${appConfig.game === 'aoe2' ? 'top-0 left-0' : 'top-1 left-1'}`}>
                             {players.some((p) => p.profileId === user && p.won === true && (freeForAll || p.team != -1)) && (
-                                <Icon size={isMedium ? 20 : 12} icon="crown" color={appConfig.game === 'aoe2' ? 'brand' : 'brand'} />
+                                <Icon size={isMedium ? 20 : 12} icon={faCrown} color={appConfig.game === 'aoe2' ? 'brand' : 'brand'} />
                             )}
 
                             {user == null && players.some((p) => p.won != null) && appConfig.game !== 'aoe2' && (
@@ -86,16 +87,16 @@ export function MatchCard(props: MatchCardProps) {
                             )}
 
                             {players.some((p) => p.profileId === user && p.won === false && (freeForAll || p.team != -1)) && (
-                                <Icon size={isMedium ? 20 : 12} icon="skull" color={appConfig.game === 'aoe2' ? 'subtle' : 'subtle'} />
+                                <Icon size={isMedium ? 20 : 12} icon={faSkull} color={appConfig.game === 'aoe2' ? 'subtle' : 'subtle'} />
                             )}
 
                             {match.abandoned && (
-                                <Icon size={isMedium ? 20 : 12} icon="ban" color={appConfig.game === 'aoe2' ? 'subtle' : 'subtle'} />
+                                <Icon size={isMedium ? 20 : 12} icon={faBan} color={appConfig.game === 'aoe2' ? 'subtle' : 'subtle'} />
                             )}
 
                             {Platform.OS === 'web' && !match.finished && !match.abandoned && appConfig.game === 'aoe2' && (
                                 <Link className="pl-1" href={`aoe2de://1/${match.matchId}`} target="_blank">
-                                    <Icon size={isMedium ? 20 : 12} icon="eye" color="brand" />
+                                    <Icon size={isMedium ? 20 : 12} icon={faEye} color="brand" />
                                 </Link>
                             )}
                         </View>

--- a/src/components/match/match-info.tsx
+++ b/src/components/match/match-info.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '@app/helper/translate';
 import { Card } from '@app/components/card';
 import { ScrollView } from '@app/components/scroll-view';
 import { Icon } from '@app/components/icon';
+import { faClock, faMemoCircleInfo, faRunning, faWrench } from '@fortawesome/sharp-solid-svg-icons';
 import { appConfig } from '@nex/dataset';
 import { tournamentsEnabled, useUpcomingTournamentMatches } from '@app/api/tournaments';
 import { differenceInMilliseconds, differenceInMinutes } from 'date-fns';
@@ -91,7 +92,7 @@ export default function MatchInfo(props: Props) {
                     </Pressable>
                 )}
                 <View className="flex-row items-center gap-1">
-                    <Icon icon="clock" size={14} color="subtle" />
+                    <Icon icon={faClock} size={14} color="subtle" />
                     <Text color="subtle">
                         {match.finished ? (
                             duration
@@ -102,13 +103,13 @@ export default function MatchInfo(props: Props) {
                 </View>
                 {appConfig.game === 'aoe2' && (
                     <View className="flex-row items-center gap-1">
-                        <Icon icon="running" size={14} color="subtle" />
+                        <Icon icon={faRunning} size={14} color="subtle" />
                         <Text color="subtle">{match.speedName}</Text>
                     </View>
                 )}
 
                 <View className="flex-row items-center gap-1">
-                    <Icon icon="memo-circle-info" size={14} color="subtle" />
+                    <Icon icon={faMemoCircleInfo} size={14} color="subtle" />
                     <Text color="subtle" numberOfLines={1} selectable>
                         {match.matchId}
                     </Text>
@@ -127,7 +128,7 @@ export default function MatchInfo(props: Props) {
                 )}
 
                 <View className="flex-row items-center gap-1">
-                    {match.modGameMode && <Icon icon="wrench" size={14} color="subtle" />}
+                    {match.modGameMode && <Icon icon={faWrench} size={14} color="subtle" />}
                     <Text color="subtle" numberOfLines={1}>
                         {getModName(match.modGameMode) ?? match.gameModeName}
                     </Text>
@@ -135,7 +136,7 @@ export default function MatchInfo(props: Props) {
 
                 {match.modTuningPack && (
                     <View className="flex-row items-center gap-1">
-                        <Icon icon="wrench" size={14} color="subtle" />
+                        <Icon icon={faWrench} size={14} color="subtle" />
 
                         <Text color="subtle" numberOfLines={1}>
                             {getModName(match.modTuningPack) ?? '???'}
@@ -144,7 +145,7 @@ export default function MatchInfo(props: Props) {
                 )}
                 {match.modDataset && (
                     <View className="flex-row items-center gap-1">
-                        <Icon icon="wrench" size={14} color="subtle" />
+                        <Icon icon={faWrench} size={14} color="subtle" />
 
                         <Text color="subtle" numberOfLines={1}>
                             {getModName(match.modDataset) ?? '???'}

--- a/src/components/match/match-player.tsx
+++ b/src/components/match/match-player.tsx
@@ -10,6 +10,7 @@ import { Link } from 'expo-router';
 import { Platform, Pressable, TouchableOpacity, View } from 'react-native';
 
 import { Icon } from '../icon';
+import { faBan, faCheckCircle, faCloudDownloadAlt, faCrown, faFamily, faSkull } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from '../text';
 import TwitchBadge from '@app/view/components/badge/twitch-badge';
 import React from 'react';
@@ -60,21 +61,21 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({ match, player, highlig
                     <Text variant={highlight ? 'header-xs' : 'body'} numberOfLines={1} className="shrink">
                         {player.name}
                     </Text>
-                    {player.status === 'player' && player.verified && <Icon icon="check-circle" color="brand" size={12} className="w-6" />}
+                    {player.status === 'player' && player.verified && <Icon icon={faCheckCircle} color="brand" size={12} className="w-6" />}
                     {twitch && (
                         <View className={reverse ? 'mr-2' : 'ml-2'}>
                             <TwitchBadge channelUrl={player?.socialTwitchChannelUrl} channel={player?.socialTwitchChannel} condensed />
                         </View>
                     )}
                     {player.status === 'player' && !player.verified && player.shared && (
-                        <Icon icon="family" color="brand" size={12} className="w-6" />
+                        <Icon icon={faFamily} color="brand" size={12} className="w-6" />
                     )}
                 </TouchableOpacity>
             </Link>
 
             {Platform.OS === 'web' && appConfig.game === 'aoe2' && canDownloadRec && (
                 <Pressable onPress={downloadRec}>
-                    <Icon icon="cloud-download-alt" color="accent-gray-500" />
+                    <Icon icon={faCloudDownloadAlt} color="accent-gray-500" />
                 </Pressable>
             )}
 
@@ -90,9 +91,9 @@ export const MatchPlayer: React.FC<MatchPlayerProps> = ({ match, player, highlig
 
             {(match.finished || match.abandoned) && (
                 <View className="w-5">
-                    {player.won === true && (freeForAll || player.team != -1) && <Icon icon="crown" color="brand" />}
-                    {player.won === false && (freeForAll || player.team != -1) && <Icon icon="skull" color="subtle" />}
-                    {player.won == null && (freeForAll || player.team != -1) && <Icon icon="ban" color="subtle" />}
+                    {player.won === true && (freeForAll || player.team != -1) && <Icon icon={faCrown} color="brand" />}
+                    {player.won === false && (freeForAll || player.team != -1) && <Icon icon={faSkull} color="subtle" />}
+                    {player.won == null && (freeForAll || player.team != -1) && <Icon icon={faBan} color="subtle" />}
                 </View>
             )}
         </View>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,6 +11,7 @@ import { useBreakpoints } from '@app/hooks/use-breakpoints';
 import { InlinePlayerSearch } from './inline-player-search';
 import { useEffect } from 'react';
 import { AccountMenu } from './account-menu';
+import { faSearch } from '@fortawesome/sharp-solid-svg-icons';
 
 export const NavBar: React.FC = () => {
     const router = useRouter();
@@ -95,7 +96,7 @@ export const NavBar: React.FC = () => {
                             'flex flex-row justify-center items-center gap-2.5 rounded-lg px-4 fill-subtle hocus:bg-gold-50 dark:hocus:bg-blue-700'
                         )}
                     >
-                        <Icon size={20} icon="search" />
+                        <Icon size={20} icon={faSearch} />
                     </Link>
                 )}
 

--- a/src/components/news-popup.tsx
+++ b/src/components/news-popup.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { Platform, TouchableOpacity, View } from 'react-native';
 import WebView from 'react-native-webview';
 import { Icon } from '@app/components/icon';
+import { faTimes } from '@fortawesome/sharp-regular-svg-icons';
 import { BlurView } from 'expo-blur';
 import { INews } from '@app/api/helper/api.types';
 
@@ -73,7 +74,7 @@ export const NewsPopup: React.FC<{ news: INews; visible: boolean; onClose: () =>
                 <BlurView intensity={50} className="absolute left-0 right-0 top-0 p-4 flex-row" >
                     <View className="flex-1"></View>
                     <TouchableOpacity onPress={onClose}>
-                        <Icon size={24} prefix="fasr" icon="times" />
+                        <Icon size={24} icon={faTimes} />
                     </TouchableOpacity>
                 </BlurView>
 

--- a/src/components/profile-leaderboard-card.tsx
+++ b/src/components/profile-leaderboard-card.tsx
@@ -8,6 +8,7 @@ import { getCivIcon } from '../helper/civs';
 import { Image } from './uniwind/image';
 import { getMapImage } from '@app/helper/maps';
 import { Icon } from './icon';
+import { faAngleRight, faCheck, faTimes } from '@fortawesome/sharp-solid-svg-icons';
 import { IProfileLeaderboardResult } from '@app/api/helper/api.types';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { ProfileLeaderboardModal } from './profile-leaderboard-modal';
@@ -53,7 +54,7 @@ export const ProfileLeaderboardCard: React.FC<{
 
                     <View className="flex-1" />
 
-                    {canOpenModal && <Icon icon="angle-right" size={24} color="brand" />}
+                    {canOpenModal && <Icon icon={faAngleRight} size={24} color="brand" />}
                 </View>
 
                 <TextComponent variant="label-lg" color="subtle" className={cn('flex lg:hidden -my-2', !leaderboard && 'max-w-24')}>
@@ -110,9 +111,9 @@ export const ProfileLeaderboardCard: React.FC<{
                                         } rounded-full w-4 h-4 justify-center items-center`}
                                     >
                                         {match.won ? (
-                                            <Icon icon="check" color="white" size={12} />
+                                            <Icon icon={faCheck} color="white" size={12} />
                                         ) : (
-                                            match.won === false && <Icon icon="times" color="black" size={12} />
+                                            match.won === false && <Icon icon={faTimes} color="black" size={12} />
                                         )}
                                     </View>
                                 )

--- a/src/components/profile-leaderboard-modal.tsx
+++ b/src/components/profile-leaderboard-modal.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useMemo, useState } from 'react';
 import { Dialog, DialogPanel, Transition, TransitionChild } from '@headlessui/react';
 import { Icon } from './icon';
+import { faTimes } from '@fortawesome/sharp-regular-svg-icons';
 import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
 import { StatsRow } from '@app/view/components/stats-rows';
 import { IProfileRatingsLeaderboard, IStatNew } from '@app/api/helper/api.types';
@@ -98,7 +99,7 @@ export const ProfileLeaderboardModal = ({
                                         </Text>
 
                                         <TouchableOpacity onPress={onClose}>
-                                            <Icon icon="times" size={32} prefix="fasr" />
+                                            <Icon icon={faTimes} size={32} />
                                         </TouchableOpacity>
                                     </View>
 

--- a/src/components/red-bull-wololo-live-standings/_components/info-modal.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/info-modal.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@app/components/icon';
+import { faTimes } from '@fortawesome/sharp-solid-svg-icons';
 import { Image } from '@app/components/uniwind/image';
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
 import { Fragment } from 'react';
@@ -34,7 +35,7 @@ export const InfoModal = ({ onClose, isVisible, countdownDate }: { isVisible: bo
                             <DialogPanel className="w-full md:max-w-md lg:max-w-lg transform overflow-hidden rounded-2xl bg-blue-950 pt-2 p-6 text-left align-middle shadow-xl transition-all text-white relative">
                                 <div className="flex flex-col gap-4 mt-4 items-center">
                                     <button onClick={onClose} className="absolute top-4 right-4">
-                                        <Icon icon="times" size={24} color="white" />
+                                        <Icon icon={faTimes} size={24} color="white" />
                                     </button>
 
                                     <Image

--- a/src/components/red-bull-wololo-live-standings/_components/match-card.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/match-card.tsx
@@ -4,6 +4,7 @@ import { RatingDiff } from './rating-diff';
 import Countdown from 'react-countdown';
 import { formatAgo, getDuration } from '@nex/data';
 import { Icon } from '@app/components/icon';
+import { faCrown, faEye, faSignalAltSlash, faSkull } from '@fortawesome/sharp-solid-svg-icons';
 import cn from 'classnames';
 import { sortTeamByCurrentPlayer } from '../../../utils/match';
 
@@ -23,18 +24,18 @@ export const MatchCard = ({
     return (
         <div className="relative flex flex-row gap-3 items-center text-sm w-full">
             {match.players.some((p) => p.profileId === userId && p.won === true) && (
-                <Icon icon="crown" color="accent-[#f9b806]" className="absolute top-1" />
+                <Icon icon={faCrown} color="accent-[#f9b806]" className="absolute top-1" />
             )}
 
-            {match.players.some((p) => p.profileId === userId && p.won === false) && <Icon icon="skull" className="absolute top-1" color="white" />}
+            {match.players.some((p) => p.profileId === userId && p.won === false) && <Icon icon={faSkull} className="absolute top-1" color="white" />}
 
             {!match.finished &&
                 (index === 0 ? (
                     <a href={`aoe2de://1/${match.matchId}`} target="_blank" className="absolute top-0" rel="noreferrer">
-                        <Icon icon="eye" color="accent-[#EAC65E]" />
+                        <Icon icon={faEye} color="accent-[#EAC65E]" />
                     </a>
                 ) : (
-                    <Icon icon="signal-alt-slash" color="white" className="absolute top-1" />
+                    <Icon icon={faSignalAltSlash} color="white" className="absolute top-1" />
                 ))}
 
             <img src={match.mapImageUrl} className="w-16 h-16" />

--- a/src/components/red-bull-wololo-live-standings/_components/player-list.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/player-list.tsx
@@ -12,6 +12,7 @@ import { reformatTeamMatch } from '../util';
 import { initMatchSubscription } from '@app/api/socket/ongoing';
 import { dateReviver } from '@nex/data';
 import { Icon } from '@app/components/icon';
+import { faArrowsRotate, faSpinner } from '@fortawesome/sharp-solid-svg-icons';
 import { InlinePlayerSearch } from '@app/components/inline-player-search';
 import { PlayerModal } from './player-modal';
 import { StatsModal } from './stats-modal';
@@ -394,7 +395,7 @@ export function PlayerList({
 
                         {!isPastDeadline && <button onClick={() => refetch()} disabled={isFetching} className="cursor-pointer">
                             <Icon
-                                icon="arrows-rotate"
+                                icon={faArrowsRotate}
                                 color="accent-[#EAC65E]"
                                 className={isFetching ? 'animate-spin [animation-duration:1s]' : undefined}
                                 size={20}
@@ -455,7 +456,7 @@ export function PlayerList({
                                 {isError ? (
                                     <p className="text-lg">There was an error loading the leaderboard. Please reload the page.</p>
                                 ) : (
-                                    <Icon className="animate-spin [animation-duration:1s]" color="white" icon="spinner" size={32} />
+                                    <Icon className="animate-spin [animation-duration:1s]" color="white" icon={faSpinner} size={32} />
                                 )}
                             </td>
                         </tr>

--- a/src/components/red-bull-wololo-live-standings/_components/player-modal.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/player-modal.tsx
@@ -11,6 +11,7 @@ import { formatCustom, formatDateShort, formatMonth, formatTime, formatYear } fr
 import { MatchCard } from './match-card';
 import { reformatTeamMatch } from '../util';
 import { Icon } from '@app/components/icon';
+import { faSpinner, faTimes } from '@fortawesome/sharp-solid-svg-icons';
 import cn from 'classnames';
 import { Button } from '@app/components/button';
 import useDebounce from '@app/hooks/use-debounce';
@@ -264,7 +265,7 @@ export const PlayerModal = ({
                                     </div>
 
                                     <button onClick={onClose}>
-                                        <Icon color="white" icon="times" size={24} />
+                                        <Icon color="white" icon={faTimes} size={24} />
                                     </button>
                                 </div>
 
@@ -275,7 +276,7 @@ export const PlayerModal = ({
                                         {!player.rank && (isProfileLoading || !profile) ? (
                                             <div className="flex items-center justify-center py-4">
                                                 {isProfileLoading ? (
-                                                    <Icon className="animate-spin [animation-duration:1s]" icon="spinner" color="white" size={32} />
+                                                    <Icon className="animate-spin [animation-duration:1s]" icon={faSpinner} color="white" size={32} />
                                                 ) : (
                                                     <p>Unable to fetch profile</p>
                                                 )}
@@ -496,7 +497,7 @@ export const PlayerModal = ({
                                         {isProfileLoading || !stats ? (
                                             <div className="flex items-center justify-center py-4">
                                                 {isProfileLoading ? (
-                                                    <Icon className="animate-spin [animation-duration:1s]" icon="spinner" color="white" size={32} />
+                                                    <Icon className="animate-spin [animation-duration:1s]" icon={faSpinner} color="white" size={32} />
                                                 ) : (
                                                     <p>Unable to fetch Statistics</p>
                                                 )}
@@ -571,7 +572,7 @@ export const PlayerModal = ({
                                                 {isLoading ? (
                                                     <Icon
                                                         className={isLoading ? 'animate-spin [animation-duration:1s]' : undefined}
-                                                        icon="spinner"
+                                                        icon={faSpinner}
                                                         color="white"
                                                         size={32}
                                                     />
@@ -606,7 +607,7 @@ export const PlayerModal = ({
                                                         <div className="absolute inset-0 flex flex-row justify-center">
                                                             <Icon
                                                                 className="animate-spin [animation-duration:1s]"
-                                                                icon="spinner"
+                                                                icon={faSpinner}
                                                                 color="white"
                                                                 size={24}
                                                             />

--- a/src/components/red-bull-wololo-live-standings/_components/player-row.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/player-row.tsx
@@ -8,6 +8,7 @@ import { RatingDiff } from './rating-diff';
 import { MatchCard } from './match-card';
 import { formatAgo } from '@nex/data';
 import { Icon } from '@app/components/icon';
+import { faChartLine, faEye, faFireAlt } from '@fortawesome/sharp-solid-svg-icons';
 import Countdown from 'react-countdown';
 
 export const PlayerRow = ({
@@ -131,7 +132,7 @@ export const PlayerRow = ({
                     <div className="relative hidden md:flex items-center gap-2">
                         {player.rating}
                         {player.profileId === 197964 || player.profileId === 10710012 ? '*' : ''}
-                        {player.rating === player.maxRating && <Icon icon="chart-line" color="white" size={14} />}
+                        {player.rating === player.maxRating && <Icon icon={faChartLine} color="white" size={14} />}
                         {(player.rating === player.maxRating ||
                             (status !== 'qualified' && !isPastDeadline) ||
                             player.profileId === 197964 ||
@@ -188,7 +189,7 @@ export const PlayerRow = ({
                                         className="text-[#EAC65E] font-bold align-middle hover:underline"
                                         rel="noreferrer"
                                     >
-                                        LIVE <Icon icon="eye" color="accent-[#EAC65E]" className="inline-block -mt-1" />
+                                        LIVE <Icon icon={faEye} color="accent-[#EAC65E]" className="inline-block -mt-1" />
                                     </a>{' '}
                                     on {match.mapName}
                                     <br />
@@ -210,7 +211,7 @@ export const PlayerRow = ({
                     <LastFiveMatches player={player} match={match} playerNames={playerNames} isPastDeadline={isPastDeadline} />
                     <p className={`text-sm whitespace-nowrap overflow-hidden text-ellipsis ${player.streak >= 5 ? 'font-bold' : ''}`}>
                         {formatStreak(player.streak)}{' '}
-                        {player.streak >= 5 ? <Icon icon="fire-alt" size={20} color="accent-orange-500" className="inline-block" /> : null}
+                        {player.streak >= 5 ? <Icon icon={faFireAlt} size={20} color="accent-orange-500" className="inline-block" /> : null}
                     </p>
                 </Cell>
             )}

--- a/src/components/red-bull-wololo-live-standings/_components/stats-modal.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/stats-modal.tsx
@@ -1,5 +1,6 @@
 import { WinrateCiv } from '@app/api/winrates';
 import { Icon } from '@app/components/icon';
+import { faSpinner, faTimes } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from '@app/components/text';
 import { Image } from '@app/components/uniwind/image';
 import { CivWinrateCard } from '@app/components/winrates/civ-card';
@@ -103,7 +104,7 @@ export const StatsModal = ({ onClose, isVisible, profileIds }: { isVisible: bool
                             <DialogPanel className="w-full md:max-w-md lg:max-w-7xl transform overflow-hidden rounded-2xl bg-blue-950 p-6 text-left align-middle shadow-xl transition-all text-white relative min-h-full">
                                 <div className="flex flex-col gap-4 items-center min-h-full">
                                     <button onClick={onClose} className="absolute top-4 right-4">
-                                        <Icon icon="times" size={24} color="white" />
+                                        <Icon icon={faTimes} size={24} color="white" />
                                     </button>
 
                                     <DialogTitle as="h2" className="text-2xl font-semibold">
@@ -128,7 +129,7 @@ export const StatsModal = ({ onClose, isVisible, profileIds }: { isVisible: bool
                                     <View className="gap-6 flex-1">
                                         {isFetching ? (
                                             <View className="items-center justify-center flex-1">
-                                                <Icon className="animate-spin [animation-duration:1s]" icon="spinner" color="white" size={32} />
+                                                <Icon className="animate-spin [animation-duration:1s]" icon={faSpinner} color="white" size={32} />
                                             </View>
                                         ) : (
                                             convertedStats.map((stat, index) => {

--- a/src/view/bottom-sheet.tsx
+++ b/src/view/bottom-sheet.tsx
@@ -4,6 +4,7 @@ import { Modal, View, ScrollView, Pressable, StyleSheet, ViewStyle, Platform, To
 import { SafeAreaProvider, SafeAreaView } from '@/src/components/uniwind/safe-area-context';
 import { createStylesheet } from '../theming-new';
 import { Icon } from '@app/components/icon';
+import { faTimes } from '@fortawesome/sharp-regular-svg-icons';
 import Animated, {
     useSharedValue,
     useAnimatedStyle,
@@ -145,7 +146,7 @@ export function BottomSheet({
                                                 </Text>
                                                 {closeButton && (
                                                     <TouchableOpacity className="absolute right-0 h-full justify-center" onPress={onClose}>
-                                                        <Icon size={24} prefix="fasr" icon="times" />
+                                                        <Icon size={24} icon={faTimes} />
                                                     </TouchableOpacity>
                                                 )}
                                             </View>
@@ -163,7 +164,7 @@ export function BottomSheet({
                                                 </Text>
                                                 {closeButton && (
                                                     <TouchableOpacity className="absolute right-0 h-full justify-center" onPress={onClose}>
-                                                        <Icon size={24} prefix="fasr" icon="times" />
+                                                        <Icon size={24} icon={faTimes} />
                                                     </TouchableOpacity>
                                                 )}
                                             </View>

--- a/src/view/components/build-order/build-rating.tsx
+++ b/src/view/components/build-order/build-rating.tsx
@@ -1,4 +1,6 @@
 import { Icon } from '@app/components/icon';
+import { faStar as faStarSolid } from '@fortawesome/sharp-solid-svg-icons';
+import { faStar as faStarRegular } from '@fortawesome/sharp-regular-svg-icons';
 import { Text } from '@app/components/text';
 import { View } from 'react-native';
 
@@ -14,12 +16,12 @@ export const BuildRating: React.FC<IBuildOrder & { showCount?: boolean }> = ({ s
                 {Array(filledStars)
                     .fill(null)
                     .map((_, index) => (
-                        <Icon icon="star" size={14} key={`filled-${index}`} color="brand" />
+                        <Icon icon={faStarSolid} size={14} key={`filled-${index}`} color="brand" />
                     ))}
                 {Array(unfilledStars)
                     .fill(null)
                     .map((_, index) => (
-                        <Icon icon="star" size={14} key={`unfilled-${index}`} color="brand" prefix="fasr" />
+                        <Icon icon={faStarRegular} size={14} key={`unfilled-${index}`} color="brand" />
                     ))}
             </View>
             {showCount && (

--- a/src/view/components/match-map/timeseries.tsx
+++ b/src/view/components/match-map/timeseries.tsx
@@ -8,6 +8,7 @@ import { useAppTheme } from '@app/theming';
 import { Text } from '@app/components/text';
 import { useChartFont } from '@app/view/components/match-map/map-utils';
 import { Icon } from '@app/components/icon';
+import { faInfoCircle } from '@fortawesome/sharp-solid-svg-icons';
 import { showAlert } from '@app/helper/alert';
 
 interface Props {
@@ -72,7 +73,7 @@ export default function Timeseries({ teams, metric, title, description, explanat
                     </Text>
                     {explanation && (
                         <TouchableOpacity onPress={showExplanation}>
-                            <Icon icon="info-circle" color="subtle"></Icon>
+                            <Icon icon={faInfoCircle} color="subtle"></Icon>
                         </TouchableOpacity>
                     )}
                 </View>

--- a/src/view/components/picker.tsx
+++ b/src/view/components/picker.tsx
@@ -17,6 +17,7 @@ import React, { type CSSProperties, useMemo, useState } from 'react';
 import { useAppTheme } from '../../theming';
 import { MenuNew } from '@app/components/menu';
 import { Icon } from '@app/components/icon';
+import { faAngleDown } from '@fortawesome/sharp-solid-svg-icons';
 
 interface IPickerProps<T> {
     value?: T;
@@ -203,7 +204,7 @@ export default function Picker<T>(props: IPickerProps<T>) {
                 </select>
 
                 <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-                    <Icon icon="angle-down" />
+                    <Icon icon={faAngleDown} />
                 </div>
             </View>
         );

--- a/src/view/components/player-list.tsx
+++ b/src/view/components/player-list.tsx
@@ -2,6 +2,7 @@ import { Button } from '@app/components/button';
 import { Card } from '@app/components/card';
 import { FlatList, FlatListProps, FlatListRef } from '@app/components/flat-list';
 import { Icon } from '@app/components/icon';
+import { faAngleRight, faCircleCheck, faPlus, faUser } from '@fortawesome/sharp-solid-svg-icons';
 import { Skeleton, SkeletonText } from '@app/components/skeleton';
 import { Text } from '@app/components/text';
 import { Href, Link } from 'expo-router';
@@ -84,7 +85,7 @@ function Player<PlayerType extends IPlayerListPlayer>({
                 <View className="opacity-0 gap-1">{FullSkeleton}</View>
 
                 <View className="absolute inset-0 items-center justify-center gap-2">
-                    <Icon icon="user" color="brand" size={isMedium ? 48 : 28} />
+                    <Icon icon={faUser} color="brand" size={isMedium ? 48 : 28} />
                     <Text numberOfLines={1} variant={isMedium ? 'label' : 'body-sm'} allowFontScaling={false}>
                         Find Me
                     </Text>
@@ -105,7 +106,7 @@ function Player<PlayerType extends IPlayerListPlayer>({
                 <View className="opacity-0 gap-1">{FullSkeleton}</View>
 
                 <View className="absolute inset-0 items-center justify-center gap-2">
-                    <Icon icon="plus" color="brand" size={isMedium ? 48 : 28} />
+                    <Icon icon={faPlus} color="brand" size={isMedium ? 48 : 28} />
                     <Text numberOfLines={1} variant={isMedium ? 'label' : 'body-sm'} allowFontScaling={false}>
                         Add Player
                     </Text>
@@ -137,11 +138,11 @@ function Player<PlayerType extends IPlayerListPlayer>({
                 {image ? image(player) : <Image source={{ uri: player.avatarMediumUrl }} className="w-7 h-7 md:w-12 md:h-12 rounded-full" />}
                 {!!player.name && (
                     <View className="flex-row gap-1 max-w-full items-center">
-                        {isMe && !hideIcons && <Icon color="brand" icon="user" size={12} />}
+                        {isMe && !hideIcons && <Icon color="brand" icon={faUser} size={12} />}
                         <Text numberOfLines={1} variant={isMedium ? 'label' : 'body-sm'} allowFontScaling={false}>
                             {player.name}
                         </Text>
-                        {!isMe && !hideIcons && player.profileId && player.verified && <Icon color="brand" icon="circle-check" size={12} />}
+                        {!isMe && !hideIcons && player.profileId && player.verified && <Icon color="brand" icon={faCircleCheck} size={12} />}
                     </View>
                 )}
 
@@ -171,8 +172,8 @@ function Player<PlayerType extends IPlayerListPlayer>({
                         <Text numberOfLines={1} variant="label">
                             {player.name}
                         </Text>
-                        {isMe && !hideIcons && <Icon color="brand" icon="user" size={12} />}
-                        {!isMe && !hideIcons && player.profileId && player.verified && <Icon color="brand" icon="circle-check" size={12} />}
+                        {isMe && !hideIcons && <Icon color="brand" icon={faUser} size={12} />}
+                        {!isMe && !hideIcons && player.profileId && player.verified && <Icon color="brand" icon={faCircleCheck} size={12} />}
                     </View>
                     {footer ? (
                         footer(player)
@@ -190,7 +191,7 @@ function Player<PlayerType extends IPlayerListPlayer>({
                         </Button>
                     )}
                 </View>
-                <Icon icon="angle-right" color="brand" size={20} />
+                <Icon icon={faAngleRight} color="brand" size={20} />
             </TouchableOpacity>
         </Wrapper>
     );

--- a/src/view/components/recent-searches.tsx
+++ b/src/view/components/recent-searches.tsx
@@ -2,6 +2,7 @@ import { Alert, Pressable, View } from 'react-native';
 import { Text } from '@app/components/text';
 import { useTranslation } from '@app/helper/translate';
 import { Icon } from '@app/components/icon';
+import { faSearch } from '@fortawesome/sharp-solid-svg-icons';
 import { useRecentSearches } from '@app/service/recent-searches';
 import PlayerList from './player-list';
 import { IProfilesResultProfile } from '@app/api/helper/api.types';
@@ -24,7 +25,7 @@ export const RecentSearches: React.FC<RecentSearchesProps> = ({ onSelect, action
     if (data.length === 0) {
         return (
             <View className={cn('flex-1 items-center justify-center gap-2 pt-2 pb-40', containerClassName)}>
-                <Icon icon="search" size={36} color="subtle" />
+                <Icon icon={faSearch} size={36} color="subtle" />
                 <View className="items-center">
                     <Text variant="header">{getTranslation('search.recent.empty.title')}</Text>
                     <Text color="subtle">{getTranslation('search.recent.empty.description')}</Text>

--- a/src/view/tournaments/stage-card.tsx
+++ b/src/view/tournaments/stage-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardProps } from '@app/components/card';
 import { Icon, IconProps } from '@app/components/icon';
+import { faMinus } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from '@app/components/text';
 import { timeStatus } from '@app/helper/tournaments';
 import { format, isSameDay } from 'date-fns';
@@ -46,7 +47,7 @@ export const StageCard: React.FC<StageCardProps> = ({ title, matches, ...props }
                     <Text variant="label" color="subtle">
                         {text}
                     </Text>
-                    {start || end ? <Icon icon="minus" size={12} color="subtle" /> : null}
+                    {start || end ? <Icon icon={faMinus} size={12} color="subtle" /> : null}
                     <Text color="subtle">
                         {start && formatCustom(start, 'LLL d')}
                         {start && end && ' - '}


### PR DESCRIPTION
## Summary

- Replaces all `icon="name"` string usages on the `<Icon>` component with explicit FontAwesome icon imports from `@fortawesome/sharp-solid-svg-icons` or `@fortawesome/sharp-regular-svg-icons`
- Removes the now-redundant `prefix` prop from all converted usages
- Dynamic prefix expressions (e.g. `prefix={x ? 'fass' : 'fasr'}`) are converted to conditional icon references using aliased imports (`faHeart as faHeartSolid` / `faHeart as faHeartRegular`)

## Why

Using imported `IconDefinition` objects instead of string names enables tree-shaking (only referenced icons are bundled), provides TypeScript type safety, and makes icon references explicit and searchable.

## Files changed

34 files across `src/app`, `src/components`, and `src/view`. No behavioural changes — purely a refactor of how icons are referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)