### PR TITLE
Fix remaining Icon string prop usages (IconName removal follow-up)

### DIFF
--- a/src/app/(main)/explore/index.tsx
+++ b/src/app/(main)/explore/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@app/components/button';
 import { Card } from '@app/components/card';
 import { Field } from '@app/components/field';
 import { FlatList } from '@app/components/flat-list';
-import { Icon, IconName } from '@app/components/icon';
+import { Icon } from '@app/components/icon';
 import { KeyboardAvoidingView } from '@app/components/keyboard-avoiding-view';
 import { Link } from '@app/components/link';
 import { ScrollView } from '@app/components/scroll-view';
@@ -41,6 +41,30 @@ import { containerClassName } from '@app/styles';
 import { useBreakpoints } from '@app/hooks/use-breakpoints';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+    faBowArrow, faCannon, faDoorOpen, faFlask, faHammer, faHorseHead, faInfoCircle,
+    faLeaf, faPersonPraying, faSailboat, faScaleUnbalanced, faSparkles, faStar,
+    faSword, faSwords, faTowerObservation, faBlockBrick,
+} from '@fortawesome/sharp-solid-svg-icons';
+
+const sectionIconMap: Record<string, IconDefinition> = {
+    'sword': faSword,
+    'bow-arrow': faBowArrow,
+    'horse-head': faHorseHead,
+    'cannon': faCannon,
+    'scale-unbalanced': faScaleUnbalanced,
+    'hammer': faHammer,
+    'sailboat': faSailboat,
+    'person-praying': faPersonPraying,
+    'star': faStar,
+    'swords': faSwords,
+    'leaf': faLeaf,
+    'flask': faFlask,
+    'sparkles': faSparkles,
+    'tower-observation': faTowerObservation,
+    'block-brick': faBlockBrick,
+    'door-open': faDoorOpen,
+};
 
 type Item =
     | { name: Civ; title: string; type: 'civ'; image?: any }
@@ -60,15 +84,15 @@ const typeAttributes: Record<
     map: { path: 'maps', labelKey: 'explore.map', title: getTechName, icon: getTechIcon },
 };
 
-const ExploreCard: React.FC<{ text: string; href: Href } & ({ image: ImageSourcePropType } | { icon: IconDefinition })> = ({ text, href, ...props }) => {
+const ExploreCard: React.FC<{ text: string; href: Href; image?: ImageSourcePropType; icon?: IconDefinition }> = ({ text, href, image, icon }) => {
     const { isMedium } = useBreakpoints();
 
     return (
         <Card direction="vertical" className="w-20 md:w-36 items-center py-2.5 px-1 gap-1 md:py-4 md:px-2 md:gap-2 justify-between" href={href}>
-            {'image' in props && props.image ? (
-                <Image className="w-8 h-8 md:w-12 md:h-12" source={props.image} contentFit="contain" />
-            ) : 'icon' in props ?(
-                <Icon icon={props.icon} size={isMedium ? 36 : 22} color="brand" />
+            {image ? (
+                <Image className="w-8 h-8 md:w-12 md:h-12" source={image} contentFit="contain" />
+            ) : icon ? (
+                <Icon icon={icon} size={isMedium ? 36 : 22} color="brand" />
             ) : null}
             <Text variant={isMedium ? 'label' : 'label-sm'} numberOfLines={1}>
                 {text}
@@ -193,7 +217,7 @@ export default function Explore() {
                         animation: 'none',
                         title: getTranslation('explore.title'),
                         headerRight: () => (
-                            <Button icon="info-circle" href="/explore/tips">
+                            <Button icon={faInfoCircle} href="/explore/tips">
                                 {getTranslation('explore.tips')}
                             </Button>
                         ),
@@ -263,7 +287,7 @@ export default function Explore() {
                                 contentContainerClassName="gap-2.5 px-4"
                                 renderItem={({ item: { title, icon } }) => (
                                     <ExploreCard
-                                        icon={icon as IconName}
+                                        icon={sectionIconMap[icon]}
                                         text={getTranslation(title as any)}
                                         href={`/explore/units?section=${title}`}
                                     />
@@ -288,7 +312,7 @@ export default function Explore() {
                                 contentContainerClassName="gap-2.5 px-4"
                                 renderItem={({ item: { title, icon } }) => (
                                     <ExploreCard
-                                        icon={icon as IconName}
+                                        icon={sectionIconMap[icon]}
                                         text={getTranslation(title as any)}
                                         href={`/explore/buildings?section=${title}`}
                                     />
@@ -314,7 +338,7 @@ export default function Explore() {
                                 renderItem={({ item: { building, civ, title } }) => (
                                     <ExploreCard
                                         image={building ? getBuildingIcon(building) : getCivIconLocal(civ!)}
-                                        icon={title ? 'star' : undefined}
+                                        icon={title ? faStar : undefined}
                                         text={
                                             building
                                                 ? getBuildingName(building).replace('Camp', '').replace('Range', '')

--- a/src/app/(main)/index.tsx
+++ b/src/app/(main)/index.tsx
@@ -27,7 +27,10 @@ import { AnimateIn } from '@app/components/animate-in';
 import { Card } from '@app/components/card';
 import { FeaturedVideos } from '@app/components/featured-videos';
 import { useLoginPopup } from '@app/hooks/use-login-popup';
-import { Icon, IconName } from '@app/components/icon';
+import { Icon } from '@app/components/icon';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faBookmark, faDiagramSankey, faRankingStar, faSearch } from '@fortawesome/sharp-solid-svg-icons';
+import { faPlaystation, faSteam, faXbox } from '@fortawesome/free-brands-svg-icons';
 import { Image } from '@app/components/uniwind/image';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { useBreakpoints } from '@app/hooks/use-breakpoints';
@@ -84,21 +87,21 @@ export default function IndexPage() {
     const { favoriteIds } = useFavoritedBuilds();
     const { followedIds } = useFollowedTournaments();
     const showTabBar = useShowTabBar();
-    const welcomeCards: Array<{ icon: IconName; title: string; description: string; href: Href }> = [
-        { icon: 'search', title: 'Find Players', description: 'Search players and view match history, civs, and ratings', href: '/players/search' },
+    const welcomeCards: Array<{ icon: IconDefinition; title: string; description: string; href: Href }> = [
+        { icon: faSearch, title: 'Find Players', description: 'Search players and view match history, civs, and ratings', href: '/players/search' },
         {
-            icon: 'ranking-star',
+            icon: faRankingStar,
             title: 'Leaderboard',
             description: 'Track top players, rankings, and current competitive ladders',
             href: '/statistics/leaderboard',
         },
         {
-            icon: 'diagram-sankey',
+            icon: faDiagramSankey,
             title: 'Tech Tree',
             description: 'Explore civilizations, units, upgrades, and unique bonuses',
             href: '/explore',
         },
-        { icon: 'bookmark', title: 'Sign in to Save', description: 'Follow players, save favorites, and sync across devices', href: '/more/account' },
+        { icon: faBookmark, title: 'Sign in to Save', description: 'Follow players, save favorites, and sync across devices', href: '/more/account' },
     ];
 
     const { isLarge, isMedium, isSmall } = useBreakpoints();
@@ -219,7 +222,7 @@ export default function IndexPage() {
                             : undefined,
                     headerRight: () =>
                         Platform.OS !== 'web' && (
-                            <Button href={'/players/search'} icon="search">
+                            <Button href={'/players/search'} icon={faSearch}>
                                 {getTranslation('home.findPlayer')}
                             </Button>
                         ),
@@ -265,22 +268,19 @@ export default function IndexPage() {
 
                                 <View className="flex-row gap-4">
                                     <Button
-                                        icon="steam"
-                                        iconPrefix="fab"
+                                        icon={faSteam}
                                         href="https://store.steampowered.com/app/813780/Age_of_Empires_II_Definitive_Edition/"
                                     >
                                         Steam
                                     </Button>
                                     <Button
-                                        icon="xbox"
-                                        iconPrefix="fab"
+                                        icon={faXbox}
                                         href="https://www.xbox.com/en-us/games/store/age-of-empires-ii-definitive-edition/9njdd0jgpp2q"
                                     >
                                         XBox
                                     </Button>
                                     <Button
-                                        icon="playstation"
-                                        iconPrefix="fab"
+                                        icon={faPlaystation}
                                         href="https://store.playstation.com/en-us/product/UP6312-PPSA18654_00-0965895154892062"
                                     >
                                         PS5

--- a/src/app/(main)/matches/index.tsx
+++ b/src/app/(main)/matches/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@app/components/button';
+import { faSearch } from '@fortawesome/sharp-solid-svg-icons';
 import { FlatList } from '@app/components/flat-list';
 import { FollowedPlayers } from '@app/components/followed-players';
 import { Match } from '@app/components/match/match';
@@ -121,7 +122,7 @@ export default function MatchesPage() {
                     title: getTranslation('matches.title'),
                     headerRight: () =>
                         showTabBar ? (
-                            <Button href={'/players/search'} icon="search">
+                            <Button href={'/players/search'} icon={faSearch}>
                                 {getTranslation('matches.findPlayer')}
                             </Button>
                         ) : null,

--- a/src/app/(main)/more/index.tsx
+++ b/src/app/(main)/more/index.tsx
@@ -1,5 +1,6 @@
 import { FlatList } from '@app/components/flat-list';
-import { Icon, IconName } from '@app/components/icon';
+import { Icon } from '@app/components/icon';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { Text } from '@app/components/text';
 import { Href, Link, Redirect, Stack } from 'expo-router';
 import { Platform, TouchableOpacity, View } from 'react-native';
@@ -9,10 +10,10 @@ import { useTranslation } from '@app/helper/translate';
 import { appConfig } from '@nex/dataset';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { Image } from '@app/components/uniwind/image';
-import { faAngleRight } from '@fortawesome/sharp-solid-svg-icons';
+import { faAngleRight, faCoffee, faCog, faExchangeAlt, faHandsHelping, faQuestionCircle, faUser } from '@fortawesome/sharp-solid-svg-icons';
 
 interface Link {
-    icon: IconName;
+    icon: IconDefinition;
     title: string;
     path: Href;
 }
@@ -22,15 +23,15 @@ export default function More() {
     const getTranslation = useTranslation();
 
     const links: Link[] = [
-        { icon: 'user', title: 'Account', path: '/more/account' },
-        { icon: 'cog', title: getTranslation('settings.title'), path: '/more/settings' },
-        { icon: 'question-circle', title: getTranslation('about.title'), path: '/more/about' },
-        { icon: 'exchange-alt', title: getTranslation('changelog.title'), path: '/more/changelog' },
-        { icon: 'hands-helping', title: getTranslation('footer.help'), path: 'https://discord.com/invite/gCunWKx' },
+        { icon: faUser, title: 'Account', path: '/more/account' },
+        { icon: faCog, title: getTranslation('settings.title'), path: '/more/settings' },
+        { icon: faQuestionCircle, title: getTranslation('about.title'), path: '/more/about' },
+        { icon: faExchangeAlt, title: getTranslation('changelog.title'), path: '/more/changelog' },
+        { icon: faHandsHelping, title: getTranslation('footer.help'), path: 'https://discord.com/invite/gCunWKx' },
 
         // iOS does not allow donations and android did check for aoe2 also
         ...(!((Platform.OS === 'ios' || (appConfig.game === 'aoe2' && Platform.OS !== 'web')) && isMajorRelease)
-            ? [{ icon: 'coffee', title: getTranslation('footer.buymeacoffee'), path: 'https://www.buymeacoffee.com/denniskeil' } as Link]
+            ? [{ icon: faCoffee, title: getTranslation('footer.buymeacoffee'), path: 'https://www.buymeacoffee.com/denniskeil' } as Link]
             : []),
     ];
 

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -11,7 +11,6 @@ import { Image } from './uniwind/image';
 export interface ButtonProps extends Omit<TouchableOpacityProps, 'children'> {
     children?: string;
     icon?: IconProps['icon'];
-    iconPrefix?: IconProps['prefix'];
     href?: Href;
     size?: 'small' | 'medium' | 'large';
     align?: TextProps['align'];
@@ -23,7 +22,6 @@ export const Button: React.FC<ButtonProps> = ({
     className,
     children,
     icon,
-    iconPrefix,
     onPress,
     href,
     size = 'medium',
@@ -53,7 +51,7 @@ export const Button: React.FC<ButtonProps> = ({
         <Wrapper asChild href={href!}>
             <Pressable className={`flex-row rounded items-center ${spacingSizes[size]} ${backgroundColor} ${className ?? ''}`} onPress={onPress}>
                 {image && <Image source={image} className='w-4 h-4' />}
-                {icon && <Icon color="white" icon={icon} prefix={iconPrefix} size={14} />}
+                {icon && <Icon color="white" icon={icon} size={14} />}
                 {children && (
                     <Text
                         variant={textSizes[size]}

--- a/src/components/field.tsx
+++ b/src/components/field.tsx
@@ -2,7 +2,7 @@ import { textColors } from '@app/utils/text.util';
 import { TextInput, TextInputProps, TouchableOpacity, View, ViewStyle } from 'react-native';
 
 import { Icon } from './icon';
-import { faSearch, faTimesCircle } from '@fortawesome/sharp-solid-svg-icons';
+import { faEye, faEyeSlash, faSearch, faTimesCircle } from '@fortawesome/sharp-solid-svg-icons';
 import { useState } from 'react';
 import cn from 'classnames';
 
@@ -68,7 +68,7 @@ export const Field: React.FC<FieldProps> = ({ type: inputType = 'default', style
             ) : null}
             {inputType === 'password' ? (
                 <TouchableOpacity className="absolute right-0 px-3 top-0 h-full justify-center" onPress={() => setSecureTextEntry((x) => !x)}>
-                    <Icon icon={secureTextEntry ? 'eye' : 'eye-slash'} color="subtle" />
+                    <Icon icon={secureTextEntry ? faEye : faEyeSlash} color="subtle" />
                 </TouchableOpacity>
             ) : null}
         </View>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@app/helper/translate';
 import { Platform, Pressable, View } from 'react-native';
 import { Text } from './text';
 import { Href, Link, usePathname, useRouter } from 'expo-router';
-import { Icon, IconName } from './icon';
+import { Icon } from './icon';
 import { Image } from './uniwind/image';
 import cn from 'classnames';
 import { containerClassName } from '@app/styles';
@@ -11,7 +11,8 @@ import { useBreakpoints } from '@app/hooks/use-breakpoints';
 import { InlinePlayerSearch } from './inline-player-search';
 import { useEffect } from 'react';
 import { AccountMenu } from './account-menu';
-import { faSearch } from '@fortawesome/sharp-solid-svg-icons';
+import { faChartSimple, faChess, faLandmark, faRankingStar, faSearch } from '@fortawesome/sharp-solid-svg-icons';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 
 export const NavBar: React.FC = () => {
     const router = useRouter();
@@ -25,32 +26,32 @@ export const NavBar: React.FC = () => {
 
     const getTranslation = useTranslation();
 
-    const routes: Array<{ key: string; label: string; icon: IconName; path: Href }> = [
+    const routes: Array<{ key: string; label: string; icon: IconDefinition; path: Href }> = [
         {
             key: 'matches',
             label: getTranslation('nav.matches'),
-            icon: 'chess',
+            icon: faChess,
             path: '/matches',
         },
         {
             key: 'explore',
             label: getTranslation('nav.explore'),
-            icon: 'landmark',
+            icon: faLandmark,
             path: '/explore',
         },
         {
             key: 'statistics',
             label: getTranslation('nav.stats'),
-            icon: 'chart-simple',
+            icon: faChartSimple,
             path: '/statistics',
         },
         {
             key: 'competitive',
             label: getTranslation('nav.competitive'),
-            icon: 'ranking-star',
+            icon: faRankingStar,
             path: '/competitive',
         },
-    ] as const;
+    ];
 
     const { isLarge } = useBreakpoints();
 
@@ -79,7 +80,7 @@ export const NavBar: React.FC = () => {
                                     : 'text-subtle fill-subtle hocus:bg-gold-50 dark:hocus:bg-blue-700'
                             )}
                         >
-                            <Icon size={20} icon={route.icon as IconName} color={isFocused ? 'white' : 'subtle'}/>
+                            <Icon size={20} icon={route.icon} color={isFocused ? 'white' : 'subtle'}/>
                             <Text variant="label-lg" className="uppercase mt-0.5" color={isFocused ? 'white' : 'subtle'}>
                                 {route.label}
                             </Text>

--- a/src/components/red-bull-snippet.tsx
+++ b/src/components/red-bull-snippet.tsx
@@ -4,6 +4,7 @@ import { Image } from './uniwind/image';
 import { Text } from './text';
 import { Button } from './button';
 import { Icon } from './icon';
+import { faSignal, faSignalSlash } from '@fortawesome/sharp-solid-svg-icons';
 import { useLoginPopup } from '@app/hooks/use-login-popup';
 import { useAuthProfileId } from '@app/queries/all';
 import { Link } from './link';
@@ -60,7 +61,7 @@ export const RedBullSnippet: React.FC = () => {
                 )}
 
                 <View className="flex-row gap-1 justify-center md:justify-start">
-                    <Icon icon={isPastDeadline ? 'signal-slash' : 'signal'} color="subtle" size={14} />
+                    <Icon icon={isPastDeadline ? faSignalSlash : faSignal} color="subtle" size={14} />
 
                     <Text variant="body-sm" color="subtle" className="text-center md:text-left italic">
                         {isPastDeadline ? 'Standings are now final.' : 'Standings update automatically during live matches'}

--- a/src/components/red-bull-wololo-live-standings/_components/last-five-matches.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/last-five-matches.tsx
@@ -1,5 +1,7 @@
 import { ILeaderboardPlayer, ILobbiesMatch } from '@app/api/helper/api.types';
-import { Icon, IconName } from '@app/components/icon';
+import { Icon } from '@app/components/icon';
+import { faCheck, faPause, faTimes } from '@fortawesome/sharp-solid-svg-icons';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { clone, reverse } from 'lodash';
 import { MatchCard } from './match-card';
 import { useMemo } from 'react';
@@ -31,18 +33,18 @@ export const LastFiveMatches = ({
         <div className="inline-flex gap-1.5">
             {last5MatchesWon.map((won, index) => {
                 let statusClass: string = '';
-                let icon: IconName | null = null
+                let icon: IconDefinition | null = null
 
                 if (isPastDeadline && won === null) {
                     statusClass = 'bg-blue-500';
-                    icon = 'pause';
+                    icon = faPause;
                 } else if (won === null) {
                     statusClass = `bg-gold-500 animate-pulse ${!!match ? '2xl:hover:animate-none 2xl:cursor-pointer' : ''}`;
                 } else if (won) {
-                    icon = 'check'
+                    icon = faCheck
                     statusClass = 'bg-green-500'
                 } else {
-                    icon = 'times';
+                    icon = faTimes;
                     statusClass = 'bg-red-500'
                 }
                 

--- a/src/components/red-bull-wololo-live-standings/_components/overlay-toolbar.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/overlay-toolbar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { defaultOverlayToolbarProps, useToolbarProps } from '../_providers/overlay-toolbar-context';
-import { Icon, IconName } from '@app/components/icon';
+import { Icon } from '@app/components/icon';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faBorderBottom, faBorderCenterH, faBorderCenterV, faBorderLeft, faBorderRight, faBorderTop, faClipboard } from '@fortawesome/sharp-solid-svg-icons';
 import cn from 'classnames';
 import { Button } from '@app/components/button';
 
@@ -24,9 +26,9 @@ export const OverlayToolbar: React.FC<{ options: OverlayToolbarOptions }> = ({ o
                     value="horizontal"
                     label="Horizontal Align"
                     options={[
-                        { icon: 'border-left', label: 'Left', value: 'left' },
-                        { icon: 'border-center-v', label: 'Center', value: 'center' },
-                        { icon: 'border-right', label: 'Right', value: 'right' },
+                        { icon: faBorderLeft, label: 'Left', value: 'left' },
+                        { icon: faBorderCenterV, label: 'Center', value: 'center' },
+                        { icon: faBorderRight, label: 'Right', value: 'right' },
                     ]}
                 />
             )}
@@ -36,9 +38,9 @@ export const OverlayToolbar: React.FC<{ options: OverlayToolbarOptions }> = ({ o
                     value="vertical"
                     label="Vertical Align"
                     options={[
-                        { icon: 'border-top', label: 'Top', value: 'top' },
-                        { icon: 'border-center-h', label: 'Center', value: 'center' },
-                        { icon: 'border-bottom', label: 'Bottom', value: 'bottom' },
+                        { icon: faBorderTop, label: 'Top', value: 'top' },
+                        { icon: faBorderCenterH, label: 'Center', value: 'center' },
+                        { icon: faBorderBottom, label: 'Bottom', value: 'bottom' },
                     ]}
                 />
             )}
@@ -53,7 +55,7 @@ export const OverlayToolbar: React.FC<{ options: OverlayToolbarOptions }> = ({ o
                     Reset
                 </Button>
                 <Button
-                    icon="clipboard"
+                    icon={faClipboard}
                     onPress={() => {
                         const currentUrl = new URL(window.location.href);
                         const searchParams = new URLSearchParams({ ...params, hideToolbar: 'true' });
@@ -77,7 +79,7 @@ export const OverlayToolbar: React.FC<{ options: OverlayToolbarOptions }> = ({ o
 };
 
 const AlignmentSelector: React.FC<{
-    options: Array<{ icon: IconName; label: string; value: string }>;
+    options: Array<{ icon: IconDefinition; label: string; value: string }>;
     label: string;
     value: 'horizontal' | 'vertical';
 }> = ({ options, label, value }) => {

--- a/src/components/red-bull-wololo-live-standings/_components/player-row.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/player-row.tsx
@@ -8,7 +8,7 @@ import { RatingDiff } from './rating-diff';
 import { MatchCard } from './match-card';
 import { formatAgo } from '@nex/data';
 import { Icon } from '@app/components/icon';
-import { faChartLine, faEye, faFireAlt } from '@fortawesome/sharp-solid-svg-icons';
+import { faCaretDown, faCaretUp, faChartLine, faEye, faFireAlt } from '@fortawesome/sharp-solid-svg-icons';
 import Countdown from 'react-countdown';
 
 export const PlayerRow = ({
@@ -84,7 +84,7 @@ export const PlayerRow = ({
 
                             {initialRank && initialRank !== rank && (
                                 <Icon
-                                    icon={initialRank > rank ? 'caret-up' : 'caret-down'}
+                                    icon={initialRank > rank ? faCaretUp : faCaretDown}
                                     color={initialRank > rank ? 'accent-[#22C55E]' : 'accent-[#EF4444]'}
                                     className={initialRank > rank ? 'inline-block -mt-0.5' : 'inline-block -mt-1.5'}
                                     size={16}

--- a/src/components/red-bull-wololo-live-standings/_components/rating-diff.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/rating-diff.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@app/components/icon';
+import { faMinus, faPlus } from '@fortawesome/sharp-solid-svg-icons';
 import React from 'react';
 import cn from 'classnames';
 
@@ -6,7 +7,7 @@ export const RatingDiff: React.FC<{ ratingDiff: number; suffix?: string }> = ({ 
     <span className={cn({ 'text-green-500': ratingDiff > 0, 'text-red-500': ratingDiff < 0 })}>
         {ratingDiff === 0 ? null : (
             <Icon
-                icon={ratingDiff > 0 ? 'plus' : 'minus'}
+                icon={ratingDiff > 0 ? faPlus : faMinus}
                 className="inline-block -mt-0.5"
                 color={ratingDiff > 0 ? 'accent-green-500' : 'accent-red-500'}
                 size={12}

--- a/src/components/red-bull-wololo-live-standings/_components/table.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/table.tsx
@@ -1,5 +1,6 @@
 import { ILeaderboardPlayer } from '@app/api/helper/api.types';
 import { Icon } from '@app/components/icon';
+import { faAngleDown, faAngleUp } from '@fortawesome/sharp-solid-svg-icons';
 import { HTMLAttributes } from 'react';
 
 export const HeadCell = ({
@@ -38,7 +39,7 @@ export const HeadCell = ({
                     <>
                         {' '}
                         <Icon
-                            icon={sort[1] === 'asc' ? 'angle-up' : 'angle-down'}
+                            icon={sort[1] === 'asc' ? faAngleUp : faAngleDown}
                             color={sort[0] === columnName ? 'accent-white' : 'accent-transparent'}
                             className={`max-w-4 inline-block ${hideIcon ? 'md:hidden!' : ''}`}
                         />

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -1,9 +1,10 @@
-import { IconName } from '@fortawesome/fontawesome-svg-core';
 import React, { useEffect } from 'react';
 import { Pressable, View } from 'react-native';
 import { Icon } from './icon';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faArrowUp, faBars, faChartSimple, faChess, faHome, faLandmark, faRankingStar } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from './text';
-import { usePathname, useRootNavigationState, useRouter } from 'expo-router';
+import { Href, usePathname, useRootNavigationState, useRouter } from 'expo-router';
 import { useSafeAreaInsets } from '@/src/components/uniwind/safe-area-context';
 import { useMutateScroll, useScrollPosition } from '@app/redux/reducer';
 import { useTranslation } from '@app/helper/translate';
@@ -71,50 +72,50 @@ export const TabBar: React.FC = () => {
         opacity.value = withTiming(toValue, { duration: 500 });
     }, [showTabBar]);
 
-    const routes = [
+    const routes: Array<{ key: string; additionalRoutes: string[]; label: string; icon: IconDefinition; path: Href }> = [
         {
             key: 'index',
             additionalRoutes: [],
             label: getTranslation('nav.home'),
-            icon: 'home',
+            icon: faHome,
             path: '/',
         },
         {
             key: 'matches',
             additionalRoutes: ['players'],
             label: getTranslation('nav.matches'),
-            icon: 'chess',
+            icon: faChess,
             path: '/matches',
         },
         {
             key: 'explore',
             additionalRoutes: [],
             label: getTranslation('nav.explore'),
-            icon: 'landmark',
+            icon: faLandmark,
             path: '/explore',
         },
         {
             key: 'statistics',
             additionalRoutes: [],
             label: getTranslation('nav.stats'),
-            icon: 'chart-simple',
+            icon: faChartSimple,
             path: '/statistics',
         },
         {
             key: 'competitive',
             additionalRoutes: [],
             label: getTranslation('nav.pros'),
-            icon: 'ranking-star',
+            icon: faRankingStar,
             path: '/competitive',
         },
         {
             key: 'more',
             additionalRoutes: ['auth'],
             label: getTranslation('nav.more'),
-            icon: 'bars',
+            icon: faBars,
             path: '/more',
         },
-    ] as const;
+    ];
     return (
         <>
             <Animated.View className="absolute px-4 pb-2 w-full" style={animatedArrowStyle}>
@@ -122,7 +123,7 @@ export const TabBar: React.FC = () => {
                     <View className={`${!showTabBar ? 'pointer-events-auto' : 'pointer-events-none'}`}>
                         <Button
                             className="h-10 w-10 items-center justify-center rounded-full shadow-lg shadow-blue-50 dark:shadow-black"
-                            icon="arrow-up"
+                            icon={faArrowUp}
                             hitSlop={10}
                             onPress={() => {
                                 setScrollPosition(0);
@@ -161,7 +162,7 @@ export const TabBar: React.FC = () => {
                                 key={route.label}
                                 className={`justify-center items-center py-2 flex-1 ${isFocused && 'bg-blue-800 dark:bg-gold-700'} rounded-lg`}
                             >
-                                {route.icon && <Icon color={isFocused ? 'white' : 'brand'} size={22} icon={route.icon as IconName} />}
+                                {route.icon && <Icon color={isFocused ? 'white' : 'brand'} size={22} icon={route.icon} />}
                                 <Text allowFontScaling={false} variant="nav" color={isFocused ? 'white' : 'brand'} className={`uppercase mt-2`}>
                                     {label}
                                 </Text>

--- a/src/view/components/profile.tsx
+++ b/src/view/components/profile.tsx
@@ -14,10 +14,11 @@ import { Button } from '@app/components/button';
 import { useAccount, useAuthProfileId } from '@app/queries/all';
 import { Text } from '@app/components/text';
 import { Icon } from '@app/components/icon';
+import { faChessRook, faSwords } from '@fortawesome/sharp-solid-svg-icons';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { reverse, sumBy } from 'lodash';
 import useAuth from '@/data/src/hooks/use-auth';
 import { Skeleton } from '@app/view/components/loader/skeleton';
-import { IconName } from '@fortawesome/fontawesome-svg-core';
 import { AnimateIn } from '@app/components/animate-in';
 
 interface ILeaderboardRowProps {
@@ -43,12 +44,12 @@ const mappingBadgeStr: Record<string, string> = {
     'qm_4v4': '4v4',
 }
 
-const mappingIconName: Record<string, IconName> = {
-    'rm_1v1': 'swords',
-    'rm_team': 'swords',
-    'ew_1v1': 'chess-rook',
-    'ew_team': 'chess-rook',
-    'unranked': 'swords',
+const mappingIconName: Record<string, IconDefinition> = {
+    'rm_1v1': faSwords,
+    'rm_team': faSwords,
+    'ew_1v1': faChessRook,
+    'ew_team': faChessRook,
+    'unranked': faSwords,
 }
 
 function LeaderboardRow1({ data }: ILeaderboardRowProps) {
@@ -65,7 +66,7 @@ function LeaderboardRow1({ data }: ILeaderboardRowProps) {
     // console.log('leaderboardId', leaderboardId);
     // console.log('mappingIconName[leaderboardId]', mappingIconName[leaderboardId]);
 
-    const mappedIconName = mappingIconName[leaderboardId] ?? 'swords';
+    const mappedIconName = mappingIconName[leaderboardId] ?? faSwords;
     const mappedBadgeStr = mappingBadgeStr[leaderboardId] ?? '?';
 
     return (

--- a/src/view/components/winrate.tsx
+++ b/src/view/components/winrate.tsx
@@ -11,6 +11,7 @@ import {
 import { Card } from '@app/components/card';
 import { HeaderTitle } from '@app/components/header-title';
 import { Icon } from '@app/components/icon';
+import { faCaretDown, faCaretUp } from '@fortawesome/sharp-solid-svg-icons';
 import { ProgressBar } from '@app/components/progress-bar';
 import { ScrollView } from '@app/components/scroll-view';
 import { Text } from '@app/components/text';
@@ -73,7 +74,7 @@ export default function CivDetails() {
                                 <Text variant="label-sm">#{stats.rank}</Text>
                                 {!sameRank && (
                                     <Icon
-                                        icon={stats.rank > stats.prior_rank ? 'caret-down' : 'caret-up'}
+                                        icon={stats.rank > stats.prior_rank ? faCaretDown : faCaretUp}
                                         color={stats.rank > stats.prior_rank ? 'accent-red-500' : 'accent-green-500'}
                                     />
                                 )}

--- a/src/view/components/winrate.web.tsx
+++ b/src/view/components/winrate.web.tsx
@@ -11,6 +11,7 @@ import {
 import { Card } from '@app/components/card';
 import { HeaderTitle } from '@app/components/header-title';
 import { Icon } from '@app/components/icon';
+import { faCaretDown, faCaretUp } from '@fortawesome/sharp-solid-svg-icons';
 import { ProgressBar } from '@app/components/progress-bar';
 import { ScrollView } from '@app/components/scroll-view';
 import { Text } from '@app/components/text';
@@ -82,7 +83,7 @@ export default function CivDetails() {
                                 <Text variant="label-sm">#{stats.rank}</Text>
                                 {!sameRank && (
                                     <Icon
-                                        icon={stats.rank > stats.prior_rank ? 'caret-down' : 'caret-up'}
+                                        icon={stats.rank > stats.prior_rank ? faCaretDown : faCaretUp}
                                         color={stats.rank > stats.prior_rank ? 'accent-red-500' : 'accent-green-500'}
                                     />
                                 )}

--- a/src/view/tournaments/stage-card.tsx
+++ b/src/view/tournaments/stage-card.tsx
@@ -1,6 +1,6 @@
 import { Card, CardProps } from '@app/components/card';
-import { Icon, IconProps } from '@app/components/icon';
-import { faMinus } from '@fortawesome/sharp-solid-svg-icons';
+import { Icon } from '@app/components/icon';
+import { faCircleCheck, faClock, faMinus, faWavePulse } from '@fortawesome/sharp-solid-svg-icons';
 import { Text } from '@app/components/text';
 import { timeStatus } from '@app/helper/tournaments';
 import { format, isSameDay } from 'date-fns';
@@ -14,18 +14,18 @@ export interface StageCardProps extends CardProps {
     title: string;
 }
 
-const statusMap: Record<ReturnType<typeof timeStatus>, { text: string; icon: IconProps['icon'] }> = {
+const statusMap: Record<ReturnType<typeof timeStatus>, { text: string; icon: import('@fortawesome/fontawesome-svg-core').IconDefinition }> = {
     ongoing: {
         text: 'Ongoing',
-        icon: 'wave-pulse',
+        icon: faWavePulse,
     },
     upcoming: {
         text: 'Upcoming',
-        icon: 'clock',
+        icon: faClock,
     },
     past: {
         text: 'Completed',
-        icon: 'circle-check',
+        icon: faCircleCheck,
     },
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #76. After `IconName` was removed from `IconProps`, `tsc --noEmit` revealed 18 more files still passing string literals to `<Icon>` or `<Button icon>`. This PR converts all of them to imported `IconDefinition` objects.

## What changed

- **`button.tsx`** — removed `iconPrefix` prop entirely (the `prefix` prop it referenced no longer exists on `IconProps`)
- **`field.tsx`** — `'eye'`/`'eye-slash'` conditional → `faEye`/`faEyeSlash`
- **`tab-bar.tsx` / `navbar.tsx`** — route icon arrays converted from string literals to imported definitions; `Button icon="arrow-up"` → `faArrowUp`
- **`more/index.tsx`** — menu link `icon` field changed from `IconName` to `IconDefinition`
- **`index.tsx` (home)** — `welcomeCards` icons + Steam/Xbox/PlayStation brand icons from `@fortawesome/free-brands-svg-icons` (replacing the now-removed `iconPrefix="fab"`)
- **`matches/index.tsx`** — `Button icon="search"` → `faSearch`
- **`explore/index.tsx`** — added `sectionIconMap` to convert `allUnitSections`/`buildingSections` string icons (from `@nex/data`) to `IconDefinition`; `Button icon="info-circle"` → `faInfoCircle`
- **`red-bull-snippet.tsx`** — `'signal'`/`'signal-slash'` conditional
- **`last-five-matches.tsx`** — local `icon` variable type changed from `IconName | null` to `IconDefinition | null`
- **`overlay-toolbar.tsx`** — `AlignmentSelector` options and `Button icon="clipboard"` converted
- **`player-row.tsx`** — `'caret-up'`/`'caret-down'` conditional
- **`rating-diff.tsx`** — `'plus'`/`'minus'` conditional
- **`table.tsx`** — `'angle-up'`/`'angle-down'` sort indicator
- **`profile.tsx`** — `mappingIconName` record values changed from strings to `IconDefinition`
- **`winrate.tsx` / `winrate.web.tsx`** — rank change caret conditionals
- **`stage-card.tsx`** — `statusMap` string icon values replaced with imported definitions

## Verification

`npx tsc --noEmit` passes with zero errors after these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)