### PR TITLE
React Compiler: fix remaining bailouts (94% → 98% compiled)

### DIFF
--- a/src/app/(main)/competitive/index.tsx
+++ b/src/app/(main)/competitive/index.tsx
@@ -20,7 +20,7 @@ import { Stack, useFocusEffect } from 'expo-router';
 import { PlayoffMatch } from 'liquipedia';
 import { groupBy, orderBy } from 'lodash';
 import compact from 'lodash/compact';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Linking, Platform, TouchableOpacity, View } from 'react-native';
 import WebView from 'react-native-webview';
 import { useTranslation } from '@app/helper/translate';
@@ -92,83 +92,88 @@ export default function Competitive() {
         setShowSetPopup(true);
     }, [selectedSet]);
 
-    // Keep these useCallbacks: this component bails out of React Compiler (it has
-    // optional chaining inside a try/catch, which the compiler does not support
-    // yet), so the callback identity is not memoized for us. `yarn lint:compiler`
-    // will say when that changes.
-    useFocusEffect(
-        useCallback(() => {
-            setIsVideoPlaying(false);
+    useFocusEffect(() => {
+        setIsVideoPlaying(false);
 
-            return () => {
-                setIsVideoPlaying(false);
-            };
-        }, [])
-    );
+        return () => {
+            setIsVideoPlaying(false);
+        };
+    });
 
     const { data: featuredTournaments, isLoading } = useFeaturedTournaments();
 
     const playTwitchStream = async () => {
-        if (Platform.OS === 'ios') {
-            try {
-                if (Platform.OS === 'ios' && (await Linking.canOpenURL(liveTwitchAppUrl!))) {
-                    await Linking.openURL(liveTwitchAppUrl!);
-                } else {
-                    await openLinkWithCheck(liveTwitchUrl!);
-                }
-            } catch (e: any) {
-                showAlert(e.message);
-            }
-        } else {
+        if (Platform.OS !== 'ios') {
             setIsVideoPlaying(true);
+            return;
+        }
+        try {
+            // Pulled out of the `if` condition on purpose: a logical expression
+            // inside a try/catch makes React Compiler bail out on the whole
+            // component. Plain `if` statements are fine.
+            const canOpenInApp = await Linking.canOpenURL(liveTwitchAppUrl!);
+            if (canOpenInApp) {
+                await Linking.openURL(liveTwitchAppUrl!);
+            } else {
+                await openLinkWithCheck(liveTwitchUrl!);
+            }
+        } catch (e: any) {
+            showAlert(e.message);
         }
     };
 
     const embedRef = useRef<HTMLDivElement>(null);
     const [embedId, setEmbedId] = useState(`twitch-embed-${getUnixTime(new Date())}`);
 
-    useFocusEffect(
-        useCallback(() => {
-            setEmbedId(`twitch-embed-${getUnixTime(new Date())}`);
-            if (Platform.OS === 'web' && liveTwitch) {
-                // Guard against the script's onload firing after we've already
-                // navigated away — otherwise it would spin up a fresh embed on a
-                // hidden screen with nothing left to tear it down.
-                let cancelled = false;
+    useFocusEffect(() => {
+        setEmbedId(`twitch-embed-${getUnixTime(new Date())}`);
+        if (Platform.OS === 'web' && liveTwitch) {
+            // Guard against the script's onload firing after we've already
+            // navigated away — otherwise it would spin up a fresh embed on a
+            // hidden screen with nothing left to tear it down.
+            let cancelled = false;
 
-                const script = document.createElement('script');
-                script.src = 'https://embed.twitch.tv/embed/v1.js';
-                script.async = true;
-                script.onload = () => {
-                    if (cancelled || !embedRef.current) return;
-                    player.current = new (window as any).Twitch.Embed(embedRef.current.id, {
-                        width: '100%',
-                        height: isMedium ? 540 : 320,
-                        channel: liveTwitch.user_login,
-                    });
-                };
-                document.body.appendChild(script);
+            const script = document.createElement('script');
+            script.src = 'https://embed.twitch.tv/embed/v1.js';
+            script.async = true;
+            script.onload = () => {
+                if (cancelled || !embedRef.current) return;
+                player.current = new (window as any).Twitch.Embed(embedRef.current.id, {
+                    width: '100%',
+                    height: isMedium ? 540 : 320,
+                    channel: liveTwitch.user_login,
+                });
+            };
+            document.body.appendChild(script);
 
-                return () => {
-                    cancelled = true;
-                    if (script.parentNode) {
-                        document.body.removeChild(script);
+            return () => {
+                cancelled = true;
+                if (script.parentNode) {
+                    document.body.removeChild(script);
+                }
+                try {
+                    // Spelled out rather than `player.current?.getPlayer()?.pause()`:
+                    // optional chaining inside a try/catch makes React Compiler
+                    // bail out on the whole component.
+                    const embed = player.current;
+                    if (embed) {
+                        const embedPlayer = embed.getPlayer();
+                        if (embedPlayer) {
+                            embedPlayer.pause();
+                        }
                     }
-                    try {
-                        player.current?.getPlayer()?.pause();
-                    } catch {
-                        // player may not be ready yet
-                    }
-                    player.current = null;
-                    // Remove the iframe entirely; pausing alone doesn't reliably
-                    // stop playback once the screen is hidden in the stack.
-                    if (embedRef.current) {
-                        embedRef.current.innerHTML = '';
-                    }
-                };
-            }
-        }, [liveTwitch, isMedium])
-    );
+                } catch {
+                    // player may not be ready yet
+                }
+                player.current = null;
+                // Remove the iframe entirely; pausing alone doesn't reliably
+                // stop playback once the screen is hidden in the stack.
+                if (embedRef.current) {
+                    embedRef.current.innerHTML = '';
+                }
+            };
+        }
+    });
 
     return (
         <ScrollView className="flex-1" contentContainerClassName="pb-4">

--- a/src/app/(main)/competitive/tournaments/all.tsx
+++ b/src/app/(main)/competitive/tournaments/all.tsx
@@ -31,10 +31,15 @@ export default function AllTournaments() {
     const { data: tournaments = [], ...query } = useTournaments((league as TournamentCategory) || category);
     const [search, setSearch] = useState('');
     const theme = useAppTheme();
+    // Keys are bound to locals first: React Compiler cannot lower a computed key
+    // that is a call expression, and bails out on the whole component.
+    const ongoingTitle = getTranslation('tournaments.ongoing');
+    const upcomingTitle = getTranslation('tournaments.upcoming');
+    const recentTitle = getTranslation('tournaments.recent');
     const subtitleMap = {
-        [getTranslation('tournaments.ongoing')]: getTranslation('tournaments.sortedbytier'),
-        [getTranslation('tournaments.upcoming')]: getTranslation('tournaments.sortedbydate'),
-        [getTranslation('tournaments.recent')]: getTranslation('tournaments.sortedbydate'),
+        [ongoingTitle]: getTranslation('tournaments.sortedbytier'),
+        [upcomingTitle]: getTranslation('tournaments.sortedbydate'),
+        [recentTitle]: getTranslation('tournaments.sortedbydate'),
     };
     const filteredTournaments = useMemo(() => {
         const filteredTournaments = tournaments
@@ -56,7 +61,7 @@ export default function AllTournaments() {
             : query.isFetching || Platform.OS === 'web'
               ? []
               : [{ title: getTranslation('tournaments.noresults'), data: [] }];
-    }, [league, tournaments, search, query.isFetching]);
+    }, [league, tournaments, search, query.isFetching, getTranslation]);
 
     const refreshControlProps = useRefreshControl(query);
 
@@ -81,7 +86,7 @@ export default function AllTournaments() {
                     </View>
                 </View>
             ),
-        [search, league, theme, setCategory, category, setSearch, formatTier, sortedTiers]
+        [search, league, theme, setCategory, category, setSearch, formatTier, sortedTiers, getTranslation]
     );
 
     return (

--- a/src/app/(main)/competitive/tournaments/index.tsx
+++ b/src/app/(main)/competitive/tournaments/index.tsx
@@ -22,10 +22,15 @@ export default function TournamentsList() {
     const { data: allTournaments = [], ...query } = useUpcomingTournaments();
     const [search, setSearch] = useState('');
     const theme = useAppTheme();
+    // Keys are bound to locals first: React Compiler cannot lower a computed key
+    // that is a call expression, and bails out on the whole component.
+    const ongoingTitle = getTranslation('tournaments.ongoing');
+    const upcomingTitle = getTranslation('tournaments.upcoming');
+    const recentTitle = getTranslation('tournaments.recent');
     const subtitleMap = {
-        [getTranslation('tournaments.ongoing')]: getTranslation('tournaments.sortedbytier'),
-        [getTranslation('tournaments.upcoming')]: getTranslation('tournaments.sortedbydate'),
-        [getTranslation('tournaments.recent')]: getTranslation('tournaments.sortedbydate'),
+        [ongoingTitle]: getTranslation('tournaments.sortedbytier'),
+        [upcomingTitle]: getTranslation('tournaments.sortedbydate'),
+        [recentTitle]: getTranslation('tournaments.sortedbydate'),
     };
     const filteredTournaments = useMemo(() => {
         const sections: { title: string; data: Tournament[] }[] = [];
@@ -78,7 +83,7 @@ export default function TournamentsList() {
             : query.isFetching || Platform.OS === 'web'
               ? []
               : [{ title: getTranslation('tournaments.noresults'), data: [] }];
-    }, [allTournaments, search, query.isFetching]);
+    }, [allTournaments, search, query.isFetching, getTranslation]);
 
     const refreshControlProps = useRefreshControl(query);
 

--- a/src/app/(main)/more/about.tsx
+++ b/src/app/(main)/more/about.tsx
@@ -60,10 +60,14 @@ export default function AboutPage() {
             const storeUpdate = await doCheckForStoreUpdate();
             setDebugStoreUpdate(JSON.stringify(storeUpdate));
 
-            if (storeUpdate?.isAvailable) {
-                mutate(setUpdateStoreManifest(storeUpdate));
-                setState('');
-                return;
+            // Nested `if` rather than `storeUpdate?.isAvailable`: optional chaining
+            // inside a try/catch makes React Compiler bail out.
+            if (storeUpdate) {
+                if (storeUpdate.isAvailable) {
+                    mutate(setUpdateStoreManifest(storeUpdate));
+                    setState('');
+                    return;
+                }
             }
         } catch (e: any) {
             setState('');
@@ -84,9 +88,12 @@ export default function AboutPage() {
         // navigation.navigate('Error');
         // }
 
+        // Resolved outside the try: a logical expression inside a try/catch makes
+        // React Compiler bail out on the whole component.
+        const manifest = Constants.expoConfig || { empty: true };
         try {
             // delete Constants.expoConfig?.assets;
-            setDebugManifest(JSON.stringify(Constants.expoConfig || { empty: true }, null, 4));
+            setDebugManifest(JSON.stringify(manifest, null, 4));
         } catch (e) {}
     };
 

--- a/src/app/(main)/more/push.tsx
+++ b/src/app/(main)/more/push.tsx
@@ -152,7 +152,12 @@ export default function PushPage() {
 
         return () => {
             try {
-                notificationListener.current?.remove();
+                // Not `notificationListener.current?.remove()`: optional chaining
+                // inside a try/catch makes React Compiler bail out.
+                const listener = notificationListener.current;
+                if (listener) {
+                    listener.remove();
+                }
             } catch (e) {
                 log(e);
             }

--- a/src/app/(main)/more/settings.tsx
+++ b/src/app/(main)/more/settings.tsx
@@ -19,6 +19,13 @@ import { useTranslation } from '@app/helper/translate';
 import { showAlert } from '@app/helper/alert';
 import { AvailableMainPage, availableMainPages } from '@app/helper/routing';
 
+// Throwing directly inside a try/catch makes React Compiler bail out on the whole
+// component. Raising from a helper behaves identically — the catch still handles
+// it — while staying compilable.
+function throwCouldNotCreateToken(): never {
+    throw 'Could not create token';
+}
+
 export default function SettingsPage() {
     const getTranslation = useTranslation();
     const styles = useStyles();
@@ -56,7 +63,7 @@ export default function SettingsPage() {
 
                 token = await getToken();
                 if (!token) {
-                    throw 'Could not create token';
+                    throwCouldNotCreateToken();
                 }
 
                 if (Platform.OS === 'android') {

--- a/src/app/(main)/players/[profileId]/(tabs)/main-matches.tsx
+++ b/src/app/(main)/players/[profileId]/(tabs)/main-matches.tsx
@@ -44,7 +44,10 @@ export default function MainMatches(props: MainMatchesProps) {
     const realText = text.trim().length < 3 ? '' : text.trim();
     const debouncedSearch = useDebounce(realText, 600);
 
-    const { data: profile = props.profile } = useProfile(props.profile === undefined ? profileId : 0);
+    // Bound to a local first: React Compiler cannot reorder a member expression
+    // used as a destructuring default, and bails out on the whole component.
+    const profileFromProps = props.profile;
+    const { data: profile = profileFromProps } = useProfile(props.profile === undefined ? profileId : 0);
 
     const language = useLanguage();
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch, isRefetching } = useInfiniteQuery({

--- a/src/components/match/share-match-button.tsx
+++ b/src/components/match/share-match-button.tsx
@@ -13,16 +13,24 @@ export function ShareMatchButton({ profileId, matchId }: ShareMatchButtonProps) 
     const url = `https://www.${appConfig.hostAoeCompanion}/players/${profileId}/matches/${matchId}`;
 
     const onPress = async () => {
+        // Capability checks and the payload are built outside the try: logical and
+        // ternary expressions inside a try/catch make React Compiler bail out on
+        // the whole component. Plain `if` statements inside it are fine.
+        const hasNavigator = typeof navigator !== 'undefined';
+        const canWebShare = hasNavigator && !!navigator.share;
+        const canWriteClipboard = hasNavigator && !!navigator.clipboard;
+        const sharePayload = Platform.OS === 'ios' ? { url } : { message: url };
+
         try {
             if (Platform.OS === 'web') {
-                if (typeof navigator !== 'undefined' && navigator.share) {
+                if (canWebShare) {
                     await navigator.share({ url });
-                } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+                } else if (canWriteClipboard) {
                     await navigator.clipboard.writeText(url);
                 }
                 return;
             }
-            await Share.share(Platform.OS === 'ios' ? { url } : { message: url });
+            await Share.share(sharePayload);
         } catch {
             // user cancelled or sharing unavailable
         }

--- a/src/components/portal/portal-host.tsx
+++ b/src/components/portal/portal-host.tsx
@@ -19,11 +19,20 @@ const PortalContext = createContext<{
 
 let nextKey = 0;
 
+// Incremented through a helper rather than `nextKey++` inline: React Compiler
+// cannot lower an update expression whose target is a module-level binding, and
+// bails out on the whole component. (Assigning to it directly is worse — that is
+// a genuine "cannot reassign variables declared outside the component" rule
+// violation.) Keys stay globally unique, as before.
+function takeNextKey() {
+    return nextKey++;
+}
+
 export const PortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const [portals, setPortals] = useState<PortalItem[]>([]);
 
     const mount = (node: React.ReactNode) => {
-        const key = nextKey++;
+        const key = takeNextKey();
         setPortals((prev) => [...prev, { key, node }]);
         return key;
     };

--- a/src/components/red-bull-wololo-live-standings/_components/player-list.tsx
+++ b/src/components/red-bull-wololo-live-standings/_components/player-list.tsx
@@ -116,6 +116,21 @@ export function PlayerList({
         );
     };
 
+    // Declared above their first use (the queryFn below calls closeSocket, and the
+    // effect further down calls openSocket). Referencing them before declaration
+    // made React Compiler bail out on the whole component.
+    const socket = useRef<w3cwebsocket>(null);
+
+    const openSocket = (profileIds: number[]) => {
+        if (profileIds && profileIds.length > 0 && !isPastDeadline) {
+            connect(profileIds).then((s) => (socket.current = s));
+        }
+    };
+
+    const closeSocket = () => {
+        socket.current?.close();
+    };
+
     const { data, isFetching, refetch, isLoading, isError, isSuccess } = useQuery<ILeaderboard, Error, ILeaderboard>({
         queryKey: ['leaderboard-players', leaderboardId],
         queryFn: async () => {
@@ -164,17 +179,6 @@ export function PlayerList({
     }, [data, isSuccess]);
 
     const playerNames = Object.fromEntries(data?.players.map((p) => [p.profileId, { name: p.name, icon: p.countryIcon }]) ?? []);
-    const socket = useRef<w3cwebsocket>(null);
-
-    const openSocket = (profileIds: number[]) => {
-        if (profileIds && profileIds.length > 0 && !isPastDeadline) {
-            connect(profileIds).then((s) => (socket.current = s));
-        }
-    };
-
-    const closeSocket = () => {
-        socket.current?.close();
-    };
 
     const mappedPlayers = useMemo(
         () =>

--- a/src/components/skia-loader.tsx
+++ b/src/components/skia-loader.tsx
@@ -7,10 +7,15 @@ interface SkiaLoaderProps {
     fallback?: React.ReactNode;
 }
 
+// Hoisted rather than written inline as a default value: React Compiler cannot
+// reorder a JSX element used as a destructuring default, and bails out on the
+// whole component.
+const defaultFallback = <Text>Loading...</Text>;
+
 export default function SkiaLoader({
                                        getComponent,
                                        componentProps = {},
-                                       fallback = <Text>Loading...</Text>,
+                                       fallback = defaultFallback,
                                    }: SkiaLoaderProps) {
     const [Component, setComponent] = useState<ComponentType<any> | null>(null);
 

--- a/src/components/skia-loader.web.tsx
+++ b/src/components/skia-loader.web.tsx
@@ -11,10 +11,15 @@ interface SkiaLoaderProps {
     fallback?: React.ReactNode;
 }
 
+// Hoisted rather than written inline as a default value: React Compiler cannot
+// reorder a JSX element used as a destructuring default, and bails out on the
+// whole component.
+const defaultFallback = <Text>Loading...</Text>;
+
 export default function SkiaLoader({
                                        getComponent,
                                        componentProps = {},
-                                       fallback = <Text>Loading...</Text>,
+                                       fallback = defaultFallback,
                                    }: SkiaLoaderProps) {
 
     // Probably not needed because the map is only rendered after the user clicks the button, but just in case to avoid hydration error.

--- a/src/hooks/use-lazy-api.ts
+++ b/src/hooks/use-lazy-api.ts
@@ -7,6 +7,13 @@ interface ILazyApiOptions<A extends (...args: any) => any> {
     append?: (data: UnPromisify<ReturnType<A>>, newData: UnPromisify<ReturnType<A>>, args: Parameters<A>) => UnPromisify<ReturnType<A>>;
 }
 
+// Throwing directly inside a try/catch makes React Compiler bail out on the whole
+// hook. Raising from a helper keeps the exact same behaviour — the catch below
+// still handles it — while staying compilable.
+function throwMissingAppend(): never {
+    throw new Error('options.append not defined');
+}
+
 export function useLazyApi<A extends (...args: any) => any>(options: ILazyApiOptions<A>, action: A, ...defArgs: Parameters<A>) {
     const [data, setData] = useState(null as UnPromisify<ReturnType<A>>);
     const [loading, setLoading] = useState(false);
@@ -38,14 +45,17 @@ export function useLazyApi<A extends (...args: any) => any>(options: ILazyApiOpt
             if (append) {
                 if (!options.append) {
                     console.log('options.append not defined');
-                    throw new Error('options.append not defined');
+                    throwMissingAppend();
                 }
                 newData = options.append(data, newData, args);
             }
 
             // console.log('num', num, 'numref', requestRef.current);
             // Ignore result if component unmounted OR a more recent request has been started
-            if (!mountedRef.current || num < requestRef.current) return null;
+            // Split rather than `||`: a logical expression inside a try/catch makes
+            // React Compiler bail out on the whole hook.
+            if (!mountedRef.current) return null;
+            if (num < requestRef.current) return null;
 
             setData(newData);
             setLoading(false);

--- a/src/hooks/use-lazy-append-api.ts
+++ b/src/hooks/use-lazy-append-api.ts
@@ -7,6 +7,13 @@ interface ILazyApiOptions<A extends (...args: any) => any> {
     append?: (data: UnPromisify<ReturnType<A>>, newData: UnPromisify<ReturnType<A>>, args: Parameters<A>) => UnPromisify<ReturnType<A>>;
 }
 
+// Throwing directly inside a try/catch makes React Compiler bail out on the whole
+// hook. Raising from a helper keeps the exact same behaviour — the catch below
+// still handles it — while staying compilable.
+function throwMissingAppend(): never {
+    throw new Error('options.append not defined');
+}
+
 export function useLazyAppendApi<A extends (...args: any) => any>(options: ILazyApiOptions<A>, action: A, ...defArgs: Parameters<A>) {
     const [data, setData] = useState(null as UnPromisify<ReturnType<A>>);
     const [loading, setLoading] = useState(false);
@@ -41,12 +48,15 @@ export function useLazyAppendApi<A extends (...args: any) => any>(options: ILazy
             let newData = await action({ ...args[0], signal: controller.signal }) as UnPromisify<ReturnType<A>>; // 👈
 
             // Ignore result if component unmounted OR a more recent request has been started
-            if (!mountedRef.current || num < requestRef.current) return null;
+            // Split rather than `||`: a logical expression inside a try/catch makes
+            // React Compiler bail out on the whole hook.
+            if (!mountedRef.current) return null;
+            if (num < requestRef.current) return null;
 
             if (append) {
                 if (!options.append) {
                     console.log('options.append not defined');
-                    throw new Error('options.append not defined');
+                    throwMissingAppend();
                 }
                 newData = options.append(data, newData, args);
             }

--- a/src/view/components/button-picker.tsx
+++ b/src/view/components/button-picker.tsx
@@ -16,9 +16,14 @@ interface IPickerProps<T> {
     disabled?: boolean;
 }
 
+// Hoisted rather than written inline as a default value: React Compiler cannot
+// reorder an arrow function used as a destructuring default, and bails out on the
+// whole component. Also saves re-creating it on every render.
+const defaultFormatter = (value: unknown) => `${value}`;
+
 // HMR reload breaks this component at least in tech tree. Why?
 export default function ButtonPicker<T>(props: IPickerProps<T>) {
-    const { value, values, onSelect, image, style, flex = false, disabled, formatter = (x) => `${x}` } = props;
+    const { value, values, onSelect, image, style, flex = false, disabled, formatter = defaultFormatter } = props;
 
     return (
         <View className="rounded-lg overflow-hidden flex-row bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-gray-800">

--- a/src/view/components/match-map/match-analysis.tsx
+++ b/src/view/components/match-map/match-analysis.tsx
@@ -14,6 +14,12 @@ interface Props {
     matchLoading?: boolean;
 }
 
+// Hoisted rather than written inline in JSX: React Compiler cannot lower a
+// dynamic `import()` expression and bails out on the whole component. The lazy
+// loading behaviour is unchanged — the import still only runs when SkiaLoader
+// calls this.
+const loadMatchMap = () => import('@app/view/components/match-map/match-map');
+
 export default function MatchAnalysis(props: Props) {
     const { match, matchError, matchLoading } = props;
     const [analyzeNow, setAnalyzeNow] = React.useState(false);
@@ -51,7 +57,7 @@ export default function MatchAnalysis(props: Props) {
             )}
             {analysis && !analysisError && (
                 <SkiaLoader
-                    getComponent={() => import('@app/view/components/match-map/match-map')}
+                    getComponent={loadMatchMap}
                     fallback={
                         <View className="flex-row items-center justify-center h-20">
                             <View className="flex-row justify-center my-3 gap-2">

--- a/src/view/components/picker.tsx
+++ b/src/view/components/picker.tsx
@@ -50,6 +50,14 @@ function defaultCell(props: any) {
     );
 }
 
+// Hoisted rather than written inline as default values: React Compiler cannot
+// reorder an arrow function used as a destructuring default, and bails out on the
+// whole component. Also saves re-creating them on every render.
+const defaultFormatter = (value: unknown) => value as string;
+const defaultSectionFormatter = (value: string) => value;
+const defaultIcon = () => undefined;
+const defaultDivider = () => false;
+
 export default function Picker<T>(props: IPickerProps<T>) {
     const theme = useAppTheme();
     const [menu, setMenu] = useState(false);
@@ -61,11 +69,11 @@ export default function Picker<T>(props: IPickerProps<T>) {
         onSelect,
         style,
         disabled,
-        formatter = (x) => x,
-        sectionFormatter = (x) => x,
-        icon = (x) => undefined,
+        formatter = defaultFormatter,
+        sectionFormatter = defaultSectionFormatter,
+        icon = defaultIcon,
         cell = defaultCell,
-        divider = (x) => false,
+        divider = defaultDivider,
         container,
         textMinWidth = 0,
         itemHeight,

--- a/src/view/components/template-picker.tsx
+++ b/src/view/components/template-picker.tsx
@@ -12,10 +12,15 @@ interface IPickerProps<T> {
     disabled?: boolean;
 }
 
+// Hoisted rather than written inline as a default value: React Compiler cannot
+// reorder an arrow function used as a destructuring default, and bails out on the
+// whole component. Also saves re-creating it on every render.
+const defaultTemplate = (value: unknown) => value as ReactNode;
+
 export default function TemplatePicker<T>(props: IPickerProps<T>) {
     const theme = useAppTheme();
 
-    const { value, values, onSelect, style, disabled, template = (x) => x} = props;
+    const { value, values, onSelect, style, disabled, template = defaultTemplate } = props;
 
     const renderItem = (v: T, i: number) => {
         let style: ViewStyle = {};

--- a/src/view/unit/unit-stats.tsx
+++ b/src/view/unit/unit-stats.tsx
@@ -38,6 +38,12 @@ interface Props {
 
 type IFormatter = (x: number) => string;
 
+// Hoisted rather than written inline as default values: React Compiler cannot
+// reorder an arrow function used as a destructuring default, and bails out on the
+// whole component. Also saves re-creating them on every render.
+const defaultPathFormatter: IFormatter = (x) => (x || 0).toString();
+const defaultValueFormatter: IFormatter = (x: any) => x;
+
 const includeEliteDataUnitLines = ['ElephantArcher', 'BattleElephant', 'CannonGalleon', 'SteppeLancer'];
 
 function getEliteData(unitLineId: UnitLine) {
@@ -83,7 +89,7 @@ export function getUpgradeByAgeData(params: GetDataParams) {
 
 export function GetValueByPath(props: PathProps) {
     const getTranslation = useTranslation();
-    const { style, unitId, buildingId, path, formatter = (x) => (x || 0).toString() } = props;
+    const { style, unitId, buildingId, path, formatter = defaultPathFormatter } = props;
     const styles = useStyles();
     const baseData = getData({ unitId, buildingId }) as IUnitInfo;
     const upgradeByAgeData = getUpgradeByAgeData({ unitId, buildingId });
@@ -199,7 +205,7 @@ interface PathProps2 {
 }
 
 export function GetUnitValue(props: PathProps2) {
-    const { style, unitId, buildingId, prop, formatter = (x: any) => x } = props;
+    const { style, unitId, buildingId, prop, formatter = defaultValueFormatter } = props;
     return <GetValueByPath style={style} unitId={unitId} buildingId={buildingId} path={(x: Partial<IUnitInfo>) => x[prop]} formatter={formatter} />;
 }
 


### PR DESCRIPTION
Follow-up to #79. Branched fresh off `main` so the diff is just these three commits — **19 files**.

Takes the codebase from **408/436 to 428/436 compiled (94% → 98%)**, bailouts 28 → 8. Every remaining bailout is a Reanimated shared-value write or a refs-read-during-render case, deliberately left alone.

Check any time with:

```bash
yarn lint:compiler --failures-only
```

## 1. Value-producing expressions inside `try/catch` (9 components)

React Compiler can't lower a *value block* inside a `try/catch`. Plain `if` statements are fine, so the fix is to bind the value to a local before the `try`. I probed the boundary first — `&&`, `?.` and ternaries inside `try` all bail; nested plain `if`s compile.

Affects `competitive/index.tsx` (which also loses its last 2 `useCallback`s and now compiles with 64 memo slots), `more/about.tsx`, `more/push.tsx`, `share-match-button.tsx`, and both lazy-api hooks.

`throw` inside `try/catch` is a separate unsupported statement. Rather than inlining what the `catch` does — duplicating the handler and letting the two drift — the throw moves into a helper typed `(): never`. It's still caught by the same `catch`, so behaviour is identical, and `never` keeps TypeScript's narrowing intact.

Computed object keys built from a call expression are also unsupported; binding each key to a local first is enough. Fixing that in the two `tournaments/*.tsx` files then exposed a stale-dep bailout underneath (three `useMemo`s reading `getTranslation` without declaring it).

## 2. Complex expressions as destructuring defaults (8 components)

The single most common bailout in this codebase. An arrow, JSX element or member expression written inline as a default value can't be reordered:

```js
const { …, formatter = (x) => `${x}` } = props;   // ✗ bails
const { …, formatter = defaultFormatter } = props; // ✓ compiles
```

Hoisting each default to a module-scope const fixes it and is better regardless — an inline default is re-created every render.

Affects `picker.tsx` (**117 memo slots**, backs every dropdown in the app and was previously unoptimized), `button-picker.tsx`, `template-picker.tsx`, `unit-stats.tsx` ×2, both `skia-loader` variants, and `main-matches.tsx`.

## 3. Three one-offs

- **`match-analysis.tsx`** — dynamic `import()` inline in JSX, hoisted to a module-scope `loadMatchMap`. Lazy loading unchanged.
- **`portal-host.tsx`** — `nextKey++` on a module counter, moved into `takeNextKey()`. Note the obvious alternative is wrong: `nextKey = nextKey + 1` swaps the compiler Todo for a *real* rule violation (`Cannot reassign variables declared outside of the component/hook`).
- **`red-bull player-list.tsx`** — `openSocket`/`closeSocket` declared below the `useQuery` and effect that call them; moved above first use. 118 memo slots.

## Worth knowing

Fixing one bailout often reveals the next in the same function, so the count moves less than the number of fixes. Both lazy-api hooks needed two rounds.

Same effect on lint: `immutability` drops 11 → 10, while `set-state-in-effect` goes 20 → 21. That new one is pre-existing behaviour that only became *visible* — the effect calls `openSocket`, and now that it's declared before use the rule can follow the call. Verified by re-running eslint against the stashed version: 2 before, 3 after, same code path.

## Verification

- `tsc --noEmit` unchanged at the same 3 pre-existing errors
- 0 `react-hooks` errors; `exhaustive-deps` 58 → 57
- Tree verified byte-identical to the branch this was cherry-picked from

**Not runtime-tested.** Worth exercising once: the share sheet, push-notification registration, settings token flow, Twitch embed teardown, the portal system, Skia map loading, and the red-bull socket lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)