### PR TITLE
Use Reanimated get()/set() so animated components compile (98% → 99%)

### DIFF
--- a/src/app/(main)/statistics/leaderboard.tsx
+++ b/src/app/(main)/statistics/leaderboard.tsx
@@ -143,6 +143,15 @@ export default function LeaderboardPage() {
 
     const language = useLanguage();
 
+    // Declared above their first use: the append callback below and several
+    // handlers read these, and referencing them before declaration made React
+    // Compiler bail out on the whole screen.
+    const handleOffsetY = useSharedValue<number>(0);
+    const movingScrollHandle = useSharedValue(false);
+    const scrollRange = useSharedValue(0);
+    const listLength = useSharedValue(0);
+    const positionY = useSharedValue(0);
+
     const leaderboard = useLazyAppendApi(
         {
             append: (data, newData, args) => {
@@ -152,7 +161,7 @@ export default function LeaderboardPage() {
                 total.current = newData.total;
                 total2.current = newData.total;
                 list.current.length = newData.total;
-                listLength.value = newData.total;
+                listLength.set(newData.total);
                 newData.players.forEach((value, index) => (list.current[(params.page! - 1) * pageSize + index] = value));
 
                 calcRankWidth(contentOffsetY);
@@ -219,7 +228,7 @@ export default function LeaderboardPage() {
         if (!showTabBar) return;
         if (leaderboard.touched && leaderboard.lastParams?.leaderboardCountry === leaderboardCountry) return;
         list.current.length = Math.min(list.current.length, pageSize);
-        listLength.value = Math.min(list.current.length, pageSize);
+        listLength.set(Math.min(list.current.length, pageSize));
         leaderboard.reload();
         // if (auth) {
         //     myRank.reload();
@@ -330,9 +339,9 @@ export default function LeaderboardPage() {
     }, [contentOffsetY, fetchingPages.current]);
 
     const updateScrollHandlePosition = (contentOffsetY: number) => {
-        if (movingScrollHandle.value) return;
-        positionY.value = (contentOffsetY / (list.current.length * ROW_HEIGHT)) * scrollRange.value;
-        console.log('updateScrollHandlePosition', 'contentOffsetY:', contentOffsetY, 'positionY:', positionY.value);
+        if (movingScrollHandle.get()) return;
+        positionY.set((contentOffsetY / (list.current.length * ROW_HEIGHT)) * scrollRange.get());
+        console.log('updateScrollHandlePosition', 'contentOffsetY:', contentOffsetY, 'positionY:', positionY.get());
     };
 
     const handleOnScrollEndDrag = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -363,23 +372,12 @@ export default function LeaderboardPage() {
     };
 
     const inactivityTimeout = useRef<number | undefined>(undefined);
-    const handleOffsetY = useSharedValue<number>(0);
-
-    // const movingScrollHandle = useRef<boolean>();
-    const movingScrollHandle = useSharedValue(false);
-
-    // const scrollRange = useRef<number>(0);
-    const scrollRange = useSharedValue(0);
-
-    const listLength = useSharedValue(0);
-
     const scollingFlatlist = useRef<boolean>(false);
     const [handleVisible, setHandleVisible] = useState(true);
     const [baseMoving, setBaseMoving] = useState(false);
 
-    const positionY = useSharedValue(0);
     const handleAnimatedStyle = useAnimatedStyle(() => {
-        return { top: positionY.value };
+        return { top: positionY.get() };
     });
 
     const scrollFlatListTo = (offset: number) => {
@@ -392,9 +390,9 @@ export default function LeaderboardPage() {
         () =>
             Gesture.Pan()
                 .onBegin(() => {
-                    handleOffsetY.value = positionY.value;
-                    console.log('onBegin', 'handleOffsetY:', handleOffsetY.value, 'positionY:', positionY.value);
-                    movingScrollHandle.value = true;
+                    handleOffsetY.set(positionY.get());
+                    console.log('onBegin', 'handleOffsetY:', handleOffsetY.get(), 'positionY:', positionY.get());
+                    movingScrollHandle.set(true);
                     scheduleOnRN(setBaseMoving, true);
                 })
                 .onUpdate((e) => {
@@ -404,29 +402,29 @@ export default function LeaderboardPage() {
                     // positionY.value = next;
 
                     const min = 0;
-                    const max = scrollRange.value;
-                    const next = Math.max(Math.min(handleOffsetY.value + e.translationY, max), min);
-                    positionY.value = next;
+                    const max = scrollRange.get();
+                    const next = Math.max(Math.min(handleOffsetY.get() + e.translationY, max), min);
+                    positionY.set(next);
                     console.log(
                         'onUpdate',
                         next,
                         'handleOffsetY:',
-                        handleOffsetY.value,
+                        handleOffsetY.get(),
                         'e.translationY:',
                         e.translationY,
                         'scrollRange:',
-                        scrollRange.value
+                        scrollRange.get()
                     );
                 })
                 .onEnd(() => {
-                    const offset = positionY.value;
+                    const offset = positionY.get();
                     // const newOffset = (offset / scrollRange.value) * total.value * ROW_HEIGHT;
-                    const newOffset = (offset / scrollRange.value) * listLength.value * ROW_HEIGHT;
+                    const newOffset = (offset / scrollRange.get()) * listLength.get() * ROW_HEIGHT;
                     scheduleOnRN(scrollFlatListTo, newOffset);
-                    movingScrollHandle.value = false;
+                    movingScrollHandle.set(false);
                     scheduleOnRN(setBaseMoving, false);
-                    handleOffsetY.value = 0;
-                    console.log('onEnd', 'listLength:', listLength.value);
+                    handleOffsetY.set(0);
+                    console.log('onEnd', 'listLength:', listLength.get());
                 }),
         []
     );
@@ -449,7 +447,7 @@ export default function LeaderboardPage() {
 
     // const text = useDerivedValue(() => `#${positionY.value}`);
     // const text = useDerivedValue(() => ((positionY.value / scrollRange.value)).toFixed());
-    const handleStr = useDerivedValue(() => '#' + ((positionY.value / scrollRange.value) * listLength.value).toFixed());
+    const handleStr = useDerivedValue(() => '#' + ((positionY.get() / scrollRange.get()) * listLength.get()).toFixed());
 
     if (!showTabBar) {
         return <WebLeaderboard />;
@@ -491,7 +489,7 @@ export default function LeaderboardPage() {
                         // called later so it will work anyway
                         if (currentTarget && !(currentTarget as any)?.scrollTo) return;
 
-                        scrollRange.value = layout.height - HANDLE_RADIUS * 2 - bottom;
+                        scrollRange.set(layout.height - HANDLE_RADIUS * 2 - bottom);
                     }}
                     scrollEventThrottle={500}
                     // contentContainerClassName="pt-2 pb-4"

--- a/src/components/animate-in.tsx
+++ b/src/components/animate-in.tsx
@@ -11,8 +11,8 @@ export const AnimateIn: React.FC<PropsWithChildren<{ skipFirstAnimation?: boolea
 
     const style = useAnimatedStyle(() => {
         return {
-            height: height.value,
-            opacity: opacity.value
+            height: height.get(),
+            opacity: opacity.get()
         };
     });
 
@@ -31,12 +31,12 @@ export const AnimateIn: React.FC<PropsWithChildren<{ skipFirstAnimation?: boolea
                 className={cn(canHaveAnimationStyles ? 'absolute top-4 left-4 right-4' : 'p-4')}
                 onLayout={(e) => {
                     if (skipFirstAnimation && !hasFirstAnimationRun) {
-                        height.value = e.nativeEvent.layout.height;
-                        opacity.value = e.nativeEvent.layout.height > 0 ? 1 : 0;
+                        height.set(e.nativeEvent.layout.height);
+                        opacity.set(e.nativeEvent.layout.height > 0 ? 1 : 0);
                         setHasFirstAnimationRun(true);
                     } else {
-                        height.value = withTiming(e.nativeEvent.layout.height + 32, { duration: 250 });
-                        opacity.value = withTiming(e.nativeEvent.layout.height > 32 ? 1 : 0, { duration: 250 });
+                        height.set(withTiming(e.nativeEvent.layout.height + 32, { duration: 250 }));
+                        opacity.set(withTiming(e.nativeEvent.layout.height > 32 ? 1 : 0, { duration: 250 }));
                     }
                 }}
             >

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -57,19 +57,19 @@ export const TabBar: React.FC = () => {
     const opacity = useSharedValue(1);
 
     const animatedStyle = useAnimatedStyle(() => ({
-        opacity: opacity.value,
+        opacity: opacity.get(),
         bottom: bottom,
     }));
 
     const animatedArrowStyle = useAnimatedStyle(() => ({
         pointerEvents: 'box-none',
         bottom,
-        opacity: interpolate(opacity.value, [0, 1], [1, 0]),
+        opacity: interpolate(opacity.get(), [0, 1], [1, 0]),
     }));
 
     useEffect(() => {
         const toValue = showTabBar ? 1 : 0;
-        opacity.value = withTiming(toValue, { duration: 500 });
+        opacity.set(withTiming(toValue, { duration: 500 }));
     }, [showTabBar]);
 
     const routes: Array<{ key: string; additionalRoutes: string[]; label: string; icon: IconDefinition; path: Href }> = [

--- a/src/view/bottom-sheet.tsx
+++ b/src/view/bottom-sheet.tsx
@@ -51,20 +51,23 @@ export function BottomSheet({
     const easing = Easing.inOut(Easing.quad);
     const duration = 250;
 
-    const triggerOpen = () => bottom.value = withTiming(0, { duration, easing });
-    const triggerClose = () => bottom.value = withTiming(height, { duration, easing }, () => {
-        scheduleOnRN(setIsVisible, false)
-        if (onCloseComplete) {
-            scheduleOnRN(onCloseComplete);
-        }
-    });
+    const triggerOpen = () => bottom.set(withTiming(0, { duration, easing }));
+    const triggerClose = () =>
+        bottom.set(
+            withTiming(height, { duration, easing }, () => {
+                scheduleOnRN(setIsVisible, false);
+                if (onCloseComplete) {
+                    scheduleOnRN(onCloseComplete);
+                }
+            })
+        );
 
     const animatedStyle = useAnimatedStyle(() => {
         return {
             pointerEvents: Platform.OS === 'web' ? 'box-none' : undefined,
             flex: isFullHeight ? 1 : undefined,
-            marginBottom: interpolate(bottom.value, [-1, 0, 1], [0, 0, -1]),
-            paddingBottom: interpolate(bottom.value, [-1, 0, 1], [1, 0, 0]),
+            marginBottom: interpolate(bottom.get(), [-1, 0, 1], [0, 0, -1]),
+            paddingBottom: interpolate(bottom.get(), [-1, 0, 1], [1, 0, 0]),
         };
     }, [isFullHeight]);
 
@@ -97,7 +100,7 @@ export function BottomSheet({
                             onLayout={(e) => {
                                 const newHeight = Math.round(e.nativeEvent.layout.height);
                                 if (height === 0) {
-                                    bottom.value = newHeight;
+                                    bottom.set(newHeight);
                                 }
                                 setHeight(newHeight);
                             }}

--- a/src/view/components/match-map/time-scrubber.tsx
+++ b/src/view/components/match-map/time-scrubber.tsx
@@ -32,14 +32,15 @@ export default function TimeScrubber({time, duration} : Props) {
     const [isPlaying, setIsPlaying] = useState(false);
 
     const barWidth = useSharedValue(0);
-    const progress = useSharedValue(0);
 
     const play = () => {
         setIsPlaying(true);
-        const remaining = duration - time.value;
-        time.value = withTiming(duration, { duration: remaining/30, easing: Easing.linear }, () => {
-            scheduleOnRN(setIsPlaying, false);
-        });
+        const remaining = duration - time.get();
+        time.set(
+            withTiming(duration, { duration: remaining / 30, easing: Easing.linear }, () => {
+                scheduleOnRN(setIsPlaying, false);
+            })
+        );
     };
 
     const pause = () => {
@@ -56,29 +57,31 @@ export default function TimeScrubber({time, duration} : Props) {
             cancelAnimation(time);
         })
         .onUpdate((e) => {
-            time.value = Math.max(0, Math.min(duration, (e.x - 12) / barWidth.value * duration));
+            time.set(Math.max(0, Math.min(duration, ((e.x - 12) / barWidth.get()) * duration)));
         })
-        .onEnd(() => {
-            // progress.value = (time.value / duration) * barWidth.value;
-        });
+        .onEnd(() => {});
 
+    // `progress` used to be written from inside progressStyle and read back in
+    // handleStyle. Writing a shared value from a style worklet is a side effect in
+    // what should be a pure derivation, so both styles now derive the same width
+    // directly. `progress` is gone; behaviour is identical because handleStyle only
+    // ever saw the value progressStyle had just computed.
     const progressStyle = useAnimatedStyle(() => {
-        const width = (time.value / duration) * barWidth.value;
-        progress.value = width;
         return {
-            width: progress.value,
+            width: (time.get() / duration) * barWidth.get(),
         };
     });
 
     const handleStyle = useAnimatedStyle(() => {
+        // 10 is half the handle width, 12 is padding of the bar container
         return {
-            left: progress.value - 10 + 12, // 10 is half the handle width, 12 is padding of the bar container
+            left: (time.get() / duration) * barWidth.get() - 10 + 12,
         };
     });
 
     const animatedProps = useAnimatedProps(() => {
         return {
-            text: `${formatTimeFromMs(time.value)} / ${formatTimeFromMs(duration)}`, // this won't work with Text, only TextInput's "value"
+            text: `${formatTimeFromMs(time.get())} / ${formatTimeFromMs(duration)}`, // this won't work with Text, only TextInput's "value"
         };
     });
 
@@ -87,7 +90,8 @@ export default function TimeScrubber({time, duration} : Props) {
             <GestureDetector gesture={panGesture}>
                 <View style={styles.barContainer} className="px-3"
                       onLayout={(event) => {
-                          barWidth.value = event.nativeEvent.layout.width - 12*2; // 12 is padding of the bar container
+                          // 12 is padding of the bar container
+                          barWidth.set(event.nativeEvent.layout.width - 12 * 2);
                       }}
                 >
                     <View style={styles.track} />


### PR DESCRIPTION
**Stacked on #81** — based on that branch so the diff shows only this commit (5 files). Retargets to `main` automatically when #81 merges.

## The problem

React Compiler treats hook return values as immutable, so every `sharedValue.value = x` read as an illegal mutation and took the whole component out of the compiler — even though the writes are all in event handlers, effects and worklets, which is correct Reanimated usage.

## The fix

Reanimated ships one: `get()` and `set()` are the compiler-compatible accessors, documented under [React Compiler support](https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support). Both exist in the installed 4.3.1, and `.value` is **not** deprecated, so this is additive rather than a migration.

Verified with a probe — identical components, one difference:

```
✗ DotValue  This value cannot be modified
✓ GetSet    (7 memo slots)
```

**432/436 compiled (98% → 99%).** eslint `immutability` warnings drop **10 → 1**.

| file | shared values |
|---|---|
| `animate-in.tsx` | height, opacity |
| `tab-bar.tsx` | opacity |
| `bottom-sheet.tsx` | bottom |
| `time-scrubber.tsx` | time (a prop), barWidth |
| `leaderboard.tsx` | handleOffsetY, movingScrollHandle, scrollRange, listLength, positionY |

`leaderboard.tsx` also has its five `useSharedValue` declarations moved above their first use — a separate bailout ("accessed before it is declared").

## Beyond the mechanical rename

`time-scrubber` previously wrote `progress.value` from inside a `useAnimatedStyle` worklet and read it back in a second style. Writing a shared value from a style worklet is a side effect in what should be a pure derivation. Both styles now derive the width directly from `time`/`barWidth`, and the `progress` shared value is gone. Behaviour is unchanged — `handleStyle` only ever saw the value `progressStyle` had just computed on the same frame.

## Routes that don't work (checked, so nobody re-tries them)

- **Renaming shared values to match the compiler's ref-like pattern** — `enableTreatRefLikeIdentifiersAsRefs` defaults to true and matches `/…Ref$|^ref$/`, but doesn't apply to hook return values.
- **`"use no memo"`** — leaves the component uncompiled *and* still logs the error.
- **Reanimated 4.3.1 compiler config** — ships none of its own.

## What's left (4, untouched here)

A different problem, not library interop:

- **3 × refs read during render** — `leaderboard` (custom scroll handle), `build-focus`, `slider2`. Genuine Rules-of-React violations.
- **`tips.tsx`** — `player.currentTime = 0` mutates an expo-video object with no `get`/`set` equivalent.

## Verification

- `tsc --noEmit` unchanged at the same 3 pre-existing errors
- 0 `react-hooks` errors

**Animation-heavy and not runtime-tested.** Worth exercising: tab bar hide/show, bottom sheet open/close, AnimateIn expansion, match-map time scrubber, leaderboard scroll handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)