### PR TITLE
Fix build-focus refs-during-render bailout

### DIFF
--- a/src/view/build-order/build-focus.tsx
+++ b/src/view/build-order/build-focus.tsx
@@ -21,12 +21,18 @@ export const BuildFocus: React.FC<{
     const flatListRef = useRef<FlatList>(null);
     const theme = useAppTheme();
 
-    const viewAbilityConfigCallbackPairs = useRef(({ changed, viewableItems }: { viewableItems: Array<ViewToken>; changed: Array<ViewToken> }) => {
+    // FlatList does not support onViewableItemsChanged changing identity between
+    // renders, which is why this used to be parked in a useRef — but reading
+    // `.current` during render is itself a rules-of-react violation and took the
+    // component out of React Compiler. It only closes over setCurrentStep, which is
+    // stable, so the compiler caches it once per instance and the identity is just
+    // as stable as the ref was.
+    const handleViewableItemsChanged = ({ changed, viewableItems }: { viewableItems: Array<ViewToken>; changed: Array<ViewToken> }) => {
         if (changed) {
             const viewableSteps = viewableItems.map((item) => item.index ?? 0);
             setCurrentStep(viewableSteps[0]);
         }
-    });
+    };
 
     const goToStep = (step: number) => {
         const newStep = Math.max(step, 0);
@@ -62,7 +68,7 @@ export const BuildFocus: React.FC<{
                         viewabilityConfig={{
                             itemVisiblePercentThreshold: 100,
                         }}
-                        onViewableItemsChanged={viewAbilityConfigCallbackPairs.current}
+                        onViewableItemsChanged={handleViewableItemsChanged}
                         className="flex-1 bg-white dark:bg-blue-950"
                         data={build.build}
                         ref={flatListRef}


### PR DESCRIPTION
**Stacked on #82** — one file, one commit. Retargets automatically as the stack merges.

## The problem

`BuildFocus` parked its `onViewableItemsChanged` handler in a `useRef` and read `.current` during render to pass it to FlatList:

```jsx
const viewAbilityConfigCallbackPairs = useRef(({ changed, viewableItems }) => { … });
…
<FlatList onViewableItemsChanged={viewAbilityConfigCallbackPairs.current} />
```

The ref was there for a real reason — FlatList doesn't support that prop changing identity between renders. But reading a ref during render is itself a rules-of-react violation, and it took the whole component out of React Compiler.

## The fix

The callback only closes over `setCurrentStep`, which is stable. So the compiler caches it against `memo_cache_sentinel` — **created once per component instance, never recreated**. That's the same stability guarantee the ref was providing, so FlatList's constraint is still satisfied without reading a ref during render.

I verified that in the emitted output rather than assuming it:

```
created ONCE per instance (sentinel) — identity stable, same guarantee the ref gave
```

Also renamed to `handleViewableItemsChanged`. The old name described FlatList's `viewabilityConfigCallbackPairs` prop, which this isn't — it's a single `onViewableItemsChanged` callback.

**433/436 compiled (99%).** eslint `refs` warnings 6 → 5.

## One caveat worth knowing

This fix depends on the component compiling. If `BuildFocus` ever bails out again, the callback goes back to being recreated per render and FlatList will warn. `yarn lint:compiler` is the guard.

## What's deliberately left (3)

- **`leaderboard`** — refs read during render in the custom virtualized scroll handle. Riskiest file in the app; not worth the remaining 1%.
- **`slider2`** — passes a ref-reading callback into `pagination(...)` during render. Needs restructuring `pagination` from a call into a rendered element.
- **`tips.tsx`** — mutates an expo-video object with no `get`/`set` equivalent. Blocked upstream, not fixable locally without contorting working code.

Unlike this one, none of those are contained changes.

## Verification

- `tsc --noEmit` unchanged at the same 3 pre-existing errors
- 0 `react-hooks` errors

**Not runtime-tested.** Worth opening a build order and scrolling through the steps to confirm the highlighted step still tracks scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)