### PR TITLE
Leaderboard row: a benchmark page, and a row with no hooks in it

### DIFF
--- a/src/app/(main)/more/index.tsx
+++ b/src/app/(main)/more/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from '@app/helper/translate';
 import { appConfig } from '@nex/dataset';
 import { useShowTabBar } from '@app/hooks/use-show-tab-bar';
 import { Image } from '@app/components/uniwind/image';
-import { faAngleRight, faCoffee, faCog, faExchangeAlt, faHandsHelping, faQuestionCircle, faUser } from '@fortawesome/sharp-solid-svg-icons';
+import { faAngleRight, faClock, faCoffee, faCog, faExchangeAlt, faHandsHelping, faQuestionCircle, faUser } from '@fortawesome/sharp-solid-svg-icons';
 
 interface Link {
     icon: IconDefinition;
@@ -28,6 +28,7 @@ export default function More() {
         { icon: faQuestionCircle, title: getTranslation('about.title'), path: '/more/about' },
         { icon: faExchangeAlt, title: getTranslation('changelog.title'), path: '/more/changelog' },
         { icon: faHandsHelping, title: getTranslation('footer.help'), path: 'https://discord.com/invite/gCunWKx' },
+        { icon: faClock, title: 'Leaderboard row benchmark', path: '/statistics/leaderboard-row-benchmark' },
 
         // iOS does not allow donations and android did check for aoe2 also
         ...(!((Platform.OS === 'ios' || (appConfig.game === 'aoe2' && Platform.OS !== 'web')) && isMajorRelease)

--- a/src/app/(main)/statistics/leaderboard-row-benchmark.tsx
+++ b/src/app/(main)/statistics/leaderboard-row-benchmark.tsx
@@ -1,0 +1,382 @@
+import { Button } from '@app/components/button';
+import { LeaderboardRow, LeaderboardRowLegacy, useLeaderboardGamesLabel, useLeaderboardRowStyles } from '@app/components/leaderboard/leaderboard-row';
+import { Text } from '@app/components/text';
+import { containerClassName } from '@app/styles';
+import { Stack } from 'expo-router';
+import React, { Profiler, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { ScrollView, useWindowDimensions, View } from 'react-native';
+import { ILeaderboardPlayer } from '../../../api/helper/api.types';
+
+/**
+ * A bench for the leaderboard row, because the row is what the leaderboard costs:
+ * a commit there is rows-rendered x per-row cost, and the commit that hurts is the
+ * one where a page lands and fifty skeleton rows turn into fifty rows with data.
+ * This page reproduces exactly that transition, on demand, with no network and no
+ * list virtualization in the way, and times it.
+ *
+ * Measured per run:
+ *   js     the state flip -> useLayoutEffect after the commit carrying the data.
+ *          React render + commit, i.e. the part that blocks the JS thread.
+ *   frame  the same start -> second requestAnimationFrame after that commit, so it
+ *          also covers native layout and getting the frame out.
+ *   react  <Profiler> actualDuration for the row subtree. Dev builds only — React
+ *          does not call onRender in a release build.
+ *
+ * `frame` is the number that matches what the eye sees, `js` is the one that moves
+ * when the row itself gets cheaper. Numbers only compare within one device and one
+ * build: a dev build, with the Profiler live and a debugger attached, is several
+ * times slower than release.
+ */
+
+const ROW_COUNT = 50;
+
+// A 1x1 transparent PNG. Real avatar URLs would drag network latency into every
+// run; this still mounts and decodes an <Image> per row.
+const AVATAR_URI =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const NAMES = ['Hera', 'TheViper', 'Liereyy', 'MbL', 'Yo', 'Villese', 'DauT', 'TheMax', 'Vinchester', 'ACCM', 'Nicov', 'JorDan_AoE', 'Tim', 'Modri'];
+
+// Built once at module load: a run must time rendering, not data generation, and a
+// stable array identity keeps React.memo honest between runs.
+const PLAYERS: (ILeaderboardPlayer | undefined)[] = Array.from({ length: ROW_COUNT }, (_, i) => ({
+    clan: i % 3 === 0 ? 'GL' : '',
+    leaderboardId: 3,
+    profileId: 100000 + i,
+    name: `${NAMES[i % NAMES.length]}${i % 4 === 0 ? `_${i}` : ''}`,
+    rank: i + 1,
+    rankCountry: i + 1,
+    rating: 2600 - i * 7,
+    maxRating: 2700 - i * 7,
+    lastMatchTime: new Date(),
+    streak: 0,
+    wins: 900 + i,
+    losses: 700 + i,
+    drops: 0,
+    updatedAt: '',
+    games: 1600 + i * 3,
+    country: 'de',
+    avatarSmallUrl: AVATAR_URI,
+}));
+
+const EMPTY: (ILeaderboardPlayer | undefined)[] = Array.from({ length: ROW_COUNT }, () => undefined);
+
+type Variant = 'current' | 'legacy';
+
+const variantLabels: Record<Variant, string> = {
+    current: 'Current row',
+    legacy: 'Legacy row',
+};
+
+interface Sample {
+    js: number;
+    frame: number;
+    react?: number;
+}
+
+const now = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
+
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+const settle = async (frames: number) => {
+    for (let i = 0; i < frames; i++) {
+        await nextFrame();
+    }
+};
+
+const noopSelect = () => {};
+
+// ---------------------------------------------------------------------------
+// The thing under test
+// ---------------------------------------------------------------------------
+
+// Memoized so that recording a sample — which re-renders the page around it —
+// cannot re-render the rows and pollute the next measurement. The only prop change
+// that reaches it is the one being timed.
+const RowList = React.memo(function RowList({ variant, loaded }: { variant: Variant; loaded: boolean }) {
+    const styles = useLeaderboardRowStyles();
+    const gamesLabel = useLeaderboardGamesLabel();
+    const { width } = useWindowDimensions();
+    const players = loaded ? PLAYERS : EMPTY;
+
+    if (variant === 'legacy') {
+        return (
+            <>
+                {players.map((player, i) => (
+                    <LeaderboardRowLegacy key={i} player={player} i={i} leaderboardCountry={null} authProfileId={null} onSelect={noopSelect} />
+                ))}
+            </>
+        );
+    }
+
+    return (
+        <>
+            {players.map((player, i) => (
+                <LeaderboardRow
+                    key={i}
+                    player={player}
+                    i={i}
+                    showCountryRank={false}
+                    showGames={width >= 360}
+                    gamesLabel={gamesLabel}
+                    authProfileId={null}
+                    rankWidth={43}
+                    styles={styles}
+                    onSelect={noopSelect}
+                />
+            ))}
+        </>
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+interface Stats {
+    n: number;
+    mean: number;
+    median: number;
+    p95: number;
+    min: number;
+    max: number;
+}
+
+function quantile(sorted: number[], q: number) {
+    const pos = (sorted.length - 1) * q;
+    const lower = Math.floor(pos);
+    const upper = Math.ceil(pos);
+    if (lower === upper) return sorted[lower];
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * (pos - lower);
+}
+
+function stats(values: number[]): Stats {
+    if (values.length === 0) return { n: 0, mean: 0, median: 0, p95: 0, min: 0, max: 0 };
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        n: values.length,
+        mean: values.reduce((sum, value) => sum + value, 0) / values.length,
+        median: quantile(sorted, 0.5),
+        p95: quantile(sorted, 0.95),
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
+const ms = (value: number) => `${value.toFixed(1)} ms`;
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function LeaderboardRowBenchmarkPage() {
+    const [variant, setVariant] = useState<Variant>('current');
+    const [loaded, setLoaded] = useState(false);
+    const [running, setRunning] = useState(false);
+    const [samples, setSamples] = useState<Record<Variant, Sample[]>>({ current: [], legacy: [] });
+    const [last, setLast] = useState<Sample | null>(null);
+
+    // Written right before the state flip and read back in the layout effect below.
+    // A promise resolver is the only way to hand a value from a commit back to the
+    // async function that triggered it.
+    const pending = useRef<{ t0: number; resolve: (sample: Sample) => void } | null>(null);
+    const reactDuration = useRef<number | undefined>(undefined);
+
+    // useLayoutEffect, not useEffect: it runs in the same task as the commit, so
+    // nothing else can land in between and inflate the number.
+    useLayoutEffect(() => {
+        const request = pending.current;
+        if (!request || !loaded) return;
+        pending.current = null;
+        const js = now() - request.t0;
+        const react = reactDuration.current;
+        // Two frames: the first is scheduled from inside the commit and can still
+        // run before the frame reaches the screen.
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                request.resolve({ js, frame: now() - request.t0, react });
+            });
+        });
+    }, [loaded]);
+
+    const onRowsRender = useCallback((_id: string, _phase: string, actualDuration: number) => {
+        reactDuration.current = actualDuration;
+    }, []);
+
+    const measureOnce = async () => {
+        setLoaded(false);
+        // Let the skeleton commit finish, otherwise its work lands inside the
+        // window being timed.
+        await settle(3);
+        reactDuration.current = undefined;
+        return new Promise<Sample>((resolve) => {
+            const t0 = now();
+            pending.current = { t0, resolve };
+            setLoaded(true);
+        });
+    };
+
+    const record = (sample: Sample) => {
+        setLast(sample);
+        setSamples((current) => ({ ...current, [variant]: [...current[variant], sample] }));
+    };
+
+    const runBatch = async (count: number) => {
+        if (running) return;
+        setRunning(true);
+        for (let i = 0; i < count; i++) {
+            record(await measureOnce());
+            await settle(2);
+        }
+        setRunning(false);
+    };
+
+    // The manual button: flip the state and watch it on a real device, with the
+    // measurement taken from the same code path the batch runs use.
+    const toggle = async () => {
+        if (running) return;
+        if (loaded) {
+            setLoaded(false);
+            return;
+        }
+        setRunning(true);
+        record(await measureOnce());
+        setRunning(false);
+    };
+
+    const clear = () => {
+        if (running) return;
+        setSamples((current) => ({ ...current, [variant]: [] }));
+        setLast(null);
+    };
+
+    const switchVariant = (next: Variant) => {
+        if (running) return;
+        setVariant(next);
+        setLoaded(false);
+        setLast(null);
+    };
+
+    const currentSamples = samples[variant];
+    const jsStats = stats(currentSamples.map((sample) => sample.js));
+    const frameStats = stats(currentSamples.map((sample) => sample.frame));
+    const reactStats = stats(currentSamples.map((sample) => sample.react).filter((value): value is number => value != null));
+
+    const legacyMedian = stats(samples.legacy.map((sample) => sample.js)).median;
+    const currentMedian = stats(samples.current.map((sample) => sample.js)).median;
+    const bothMeasured = samples.legacy.length > 0 && samples.current.length > 0;
+    const delta = legacyMedian === 0 ? 0 : ((currentMedian - legacyMedian) / legacyMedian) * 100;
+
+    return (
+        <View className="flex-1">
+            <Stack.Screen options={{ title: 'Row benchmark' }} />
+
+            <View className={`gap-3 py-3 ${containerClassName}`}>
+                <View className="flex-row gap-2">
+                    {(['current', 'legacy'] as Variant[]).map((option) => (
+                        <Button
+                            key={option}
+                            size="small"
+                            className={variant === option ? '' : 'opacity-40'}
+                            onPress={() => switchVariant(option)}
+                        >
+                            {variantLabels[option]}
+                        </Button>
+                    ))}
+                </View>
+
+                <View className="flex-row flex-wrap gap-2">
+                    <Button size="small" onPress={toggle}>
+                        {loaded ? 'Show skeleton' : 'Show data (measure)'}
+                    </Button>
+                    <Button size="small" onPress={() => runBatch(10)}>
+                        Run 10x
+                    </Button>
+                    <Button size="small" onPress={() => runBatch(30)}>
+                        Run 30x
+                    </Button>
+                    <Button size="small" onPress={clear}>
+                        Clear
+                    </Button>
+                </View>
+
+                <Text variant="body-sm" color="subtle">
+                    {ROW_COUNT} rows, skeleton {'→'} data, {variantLabels[variant].toLowerCase()}
+                    {running ? ' — running…' : ''}
+                </Text>
+
+                <View className="flex-row gap-4">
+                    <Metric label="js" value={last ? ms(last.js) : '—'} sub={last ? `${((last.js / ROW_COUNT) * 1000).toFixed(0)} µs/row` : ' '} />
+                    <Metric label="frame" value={last ? ms(last.frame) : '—'} sub="incl. native layout" />
+                    <Metric label="react" value={last?.react != null ? ms(last.react) : 'n/a'} sub="Profiler, dev only" />
+                </View>
+
+                <View className="gap-0.5">
+                    <View className="flex-row">
+                        <View className="w-16" />
+                        <Text variant="label-sm" color="subtle" className="w-8 text-right">
+                            n
+                        </Text>
+                        {['mean', 'med', 'p95', 'min', 'max'].map((header) => (
+                            <Text key={header} variant="label-sm" color="subtle" className="flex-1 text-right">
+                                {header}
+                            </Text>
+                        ))}
+                    </View>
+                    <StatsRow label="js" stats={jsStats} />
+                    <StatsRow label="frame" stats={frameStats} />
+                    {reactStats.n > 0 && <StatsRow label="react" stats={reactStats} />}
+                </View>
+
+                {bothMeasured ? (
+                    <Text variant="body-sm">
+                        median js: legacy {ms(legacyMedian)} {'→'} current {ms(currentMedian)} ({delta > 0 ? '+' : ''}
+                        {delta.toFixed(0)}%)
+                    </Text>
+                ) : (
+                    <Text variant="body-xs" color="subtle">
+                        Run both variants to compare. Numbers are comparable only within one device and one build.
+                    </Text>
+                )}
+            </View>
+
+            <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 120 }}>
+                <Profiler id="leaderboard-rows" onRender={onRowsRender}>
+                    <RowList variant={variant} loaded={loaded} />
+                </Profiler>
+            </ScrollView>
+        </View>
+    );
+}
+
+function Metric({ label, value, sub }: { label: string; value: string; sub: string }) {
+    return (
+        <View className="flex-1">
+            <Text variant="label-sm" color="subtle">
+                {label}
+            </Text>
+            <Text variant="header-sm">{value}</Text>
+            <Text variant="body-xs" color="subtle">
+                {sub}
+            </Text>
+        </View>
+    );
+}
+
+function StatsRow({ label, stats: values }: { label: string; stats: Stats }) {
+    return (
+        <View className="flex-row">
+            <Text variant="label-sm" className="w-16">
+                {label}
+            </Text>
+            <Text variant="body-sm" className="w-8 text-right">
+                {values.n}
+            </Text>
+            {[values.mean, values.median, values.p95, values.min, values.max].map((value, index) => (
+                <Text key={index} variant="body-sm" className="flex-1 text-right">
+                    {values.n === 0 ? '—' : value.toFixed(1)}
+                </Text>
+            ))}
+        </View>
+    );
+}

--- a/src/app/(main)/statistics/leaderboard.tsx
+++ b/src/app/(main)/statistics/leaderboard.tsx
@@ -3,22 +3,11 @@ import { leaderboardsByType } from '@app/helper/leaderboard';
 import { useTranslation } from '@app/helper/translate';
 import { useAuthProfileId, useFollowedAndMeProfileIds, useLanguage, useLeaderboards } from '@app/queries/all';
 import { AnimatedValueText } from '@app/view/components/animated-value-text';
-import { ImageLoader } from '@app/view/components/loader/image-loader';
-import { TextLoader } from '@app/view/components/loader/text-loader';
 import { MyText } from '@app/view/components/my-text';
 import { useIsFocused } from 'expo-router/react-navigation';
 import { router, Stack } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-    Dimensions,
-    NativeScrollEvent,
-    NativeSyntheticEvent,
-    Platform,
-    StyleSheet,
-    TextStyle,
-    TouchableOpacity,
-    View,
-} from 'react-native';
+import { NativeScrollEvent, NativeSyntheticEvent, Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
@@ -37,8 +26,7 @@ import { WebLeaderboard } from '../../../components/leaderboard/web-leaderboard'
 import { LeaderboardOfficialSelect } from '@app/components/select/leaderboard-official-select';
 import { Icon } from '@app/components/icon';
 import { faArrowsAltV } from '@fortawesome/free-solid-svg-icons';
-
-const ROW_HEIGHT = 45;
+import { LeaderboardRow, ROW_HEIGHT, useLeaderboardRowStyles } from '@app/components/leaderboard/leaderboard-row';
 
 const pageSize = 100;
 
@@ -254,25 +242,38 @@ export default function LeaderboardPage() {
         router.push(`/players/${player.profileId}`);
     };
 
+    // Everything a row used to look up for itself is resolved once here instead.
+    // A row is rendered up to 50x per commit, so a per-row hook is 50 query
+    // subscriptions or 50 Appearance listeners, and isCountry() is a scan over
+    // ~250 countries. See components/leaderboard/leaderboard-row.tsx.
+    const rowStyles = useLeaderboardRowStyles();
+    // Fetched with its `{games}` placeholder intact; the row fills in the number.
+    const gamesLabel = getTranslation('leaderboard.games') ?? '';
+    const { width: windowWidth } = useWindowDimensions();
+    const showGames = windowWidth >= 360;
+    const showCountryRank = isCountry(loadedLeaderboardCountry);
+    const finalRankWidth = Math.max(myRankWidth || 43, rankWidth || 43);
+
     // LeaderboardPage compiles now, so the compiler would keep this stable on its
     // own; the useCallback is kept only because its deps are already correct and
     // removing it buys nothing.
     const _renderRow = useCallback(
         (player: ILeaderboardPlayer, i: number) => {
-            logPlayer('INIT', i, player);
             return (
-                <MemoizedRenderRow
+                <LeaderboardRow
                     player={player}
                     i={i}
-                    leaderboardCountry={loadedLeaderboardCountry}
+                    showCountryRank={showCountryRank}
+                    showGames={showGames}
+                    gamesLabel={gamesLabel}
                     authProfileId={authProfileId}
-                    rankWidth={rankWidth}
-                    myRankWidth={myRankWidth}
+                    rankWidth={finalRankWidth}
+                    styles={rowStyles}
                     onSelect={onSelect}
                 />
             );
         },
-        [myRankWidth, rankWidth, loadedLeaderboardCountry, authProfileId]
+        [finalRankWidth, showCountryRank, showGames, gamesLabel, authProfileId, rowStyles]
     );
 
     // useEffect(() => {
@@ -548,72 +549,6 @@ export default function LeaderboardPage() {
     );
 }
 
-interface RenderRowProps {
-    player: ILeaderboardPlayer;
-    i: number;
-    leaderboardCountry: string | null;
-    authProfileId?: number | null;
-    rankWidth?: number;
-    myRankWidth?: number;
-    onSelect: (player: ILeaderboardPlayer) => void;
-}
-
-function logPlayer(str: string, i: number, player: ILeaderboardPlayer, leaderboardCountry?: string | null) {
-    // if (i == 1 && player?.leaderboardId == 'rm_1v1') {
-    //     console.log(str.padEnd(8, ' '), 'ROW', i, player.rank, player?.name, player != null,
-    //         isCountry(leaderboardCountry), isCountry(leaderboardCountry) ? player?.rankCountry : player?.rank || i + 1);
-    // }
-}
-
-function RenderRow(props: RenderRowProps) {
-    const getTranslation = useTranslation();
-    const { player, i, rankWidth, myRankWidth, onSelect, leaderboardCountry, authProfileId } = props;
-
-    const styles = useStyles();
-
-    const isMe = player?.profileId != null && player?.profileId === authProfileId;
-    // Fixed height, not minHeight: getItemLayout below promises the list that
-    // every row is exactly ROW_HEIGHT. A row that rendered taller made the real
-    // layout disagree with that promise, so when a page landed and placeholder
-    // rows filled with content the list corrected itself — yanking the scroll
-    // position backwards and killing momentum mid-fling. Nothing here wraps
-    // (rank and name are both numberOfLines={1}), so pinning the height is safe.
-    const rowStyle = { height: ROW_HEIGHT };
-    const weightStyle = { fontWeight: isMe ? 'bold' : 'normal' } as TextStyle;
-    const rankWidthStyle = { width: Math.max(myRankWidth || 43, rankWidth || 43) } as TextStyle;
-
-    // console.log('Math.max(myRankWidth, rankWidth)', myRankWidth, rankWidth);
-    // console.log('Math.max(myRankWidth, rankWidth)', Math.max(myRankWidth, rankWidth));
-
-    logPlayer('RENDER', i, player, leaderboardCountry);
-
-    return (
-        <TouchableOpacity style={[styles.row, rowStyle]} disabled={player == null} onPress={() => onSelect(player)}>
-            <View style={styles.innerRowWithBorder}>
-                <TextLoader numberOfLines={1} style={[styles.cellRank, weightStyle, rankWidthStyle]}>
-                    #{isCountry(leaderboardCountry) ? player?.rankCountry : player?.rank || i + 1}
-                </TextLoader>
-
-                <TextLoader style={isMe ? styles.cellRatingMe : styles.cellRating}>{player?.rating}</TextLoader>
-                <View style={styles.cellName}>
-                    <ImageLoader source={{ uri: player?.avatarSmallUrl }} ready={player} className="w-5 h-5 mr-2 rounded-full" />
-                    <TextLoader style={isMe ? styles.nameMe : styles.name} numberOfLines={1}>
-                        {player?.name}
-                    </TextLoader>
-                </View>
-
-                {Dimensions.get('window').width >= 360 && (
-                    <TextLoader ready={player?.games} style={styles.cellGames}>
-                        {getTranslation('leaderboard.games', { games: player?.games })}
-                    </TextLoader>
-                )}
-            </View>
-        </TouchableOpacity>
-    );
-}
-
-const MemoizedRenderRow = React.memo(RenderRow);
-
 const HANDLE_RADIUS = 36;
 
 const padding = 8;
@@ -701,13 +636,6 @@ const useStyles = createStylesheet((theme) =>
             marginLeft: 25,
             // backgroundColor: 'red',
         },
-        name: {
-            flex: 1,
-        },
-        nameMe: {
-            flex: 1,
-            fontWeight: 'bold',
-        },
         cellRankMe: {
             margin: padding,
             textAlign: 'left',
@@ -715,41 +643,12 @@ const useStyles = createStylesheet((theme) =>
             // width: 60,
             fontWeight: 'bold',
         },
-        cellRank: {
-            margin: padding,
-            textAlign: 'left',
-            // backgroundColor: 'yellow',
-        },
-        cellRating: {
-            margin: padding,
-            width: 38,
-            // backgroundColor: 'yellow',
-        },
-        cellRatingMe: {
-            margin: padding,
-            width: 38,
-            fontWeight: 'bold',
-            // backgroundColor: 'yellow',
-        },
         flexRow: {
             flexDirection: 'row',
-        },
-        cellName: {
-            margin: padding,
-            flex: 4,
-            flexDirection: 'row',
-            alignItems: 'center',
         },
         cellName2: {
             margin: padding,
             flex: 4,
-        },
-        cellGames: {
-            margin: padding,
-            width: 90,
-            textAlign: 'right',
-            fontSize: 12,
-            color: theme.textNoteColor,
         },
         cellWins: {
             margin: padding,
@@ -780,23 +679,6 @@ const useStyles = createStylesheet((theme) =>
             width: '100%',
             borderBottomWidth: 1,
             borderBottomColor: theme.borderColor,
-        },
-        row: {
-            // marginRight: 30,
-            // marginLeft: 30,
-            // width: '100%',
-            // flex: 3,
-            flex: 1,
-        },
-        innerRowWithBorder: {
-            // backgroundColor: 'green',
-            flex: 1,
-            width: '100%',
-            flexDirection: 'row',
-            alignItems: 'center',
-            paddingHorizontal: 15,
-            borderBottomWidth: 1,
-            borderBottomColor: theme.lightBorderColor,
         },
         countryIcon: {
             width: 21,

--- a/src/components/leaderboard/leaderboard-row.tsx
+++ b/src/components/leaderboard/leaderboard-row.tsx
@@ -1,0 +1,327 @@
+import { isCountry } from '@app/components/select/country-select';
+import { useTranslation } from '@app/helper/translate';
+import { ImageLoader } from '@app/view/components/loader/image-loader';
+import { TextLoader } from '@app/view/components/loader/text-loader';
+import React from 'react';
+import { Dimensions, Image, Pressable, PressableStateCallbackType, StyleSheet, Text, TextStyle, TouchableOpacity, View } from 'react-native';
+import { ILeaderboardPlayer } from '../../api/helper/api.types';
+import { createStylesheet } from '../../theming-new';
+
+// Fixed height, not minHeight: the leaderboard's scroll maths promises the list
+// that every row is exactly this tall. A row that rendered taller made the real
+// layout disagree with that promise, so when a page landed and placeholder rows
+// filled with content the list corrected itself — yanking the scroll position
+// backwards and killing momentum mid-fling. Nothing in a row wraps (rank and name
+// are both numberOfLines={1}), so pinning the height is safe.
+export const ROW_HEIGHT = 45;
+
+/**
+ * The two leaderboard rows.
+ *
+ * `LeaderboardRowLegacy` is the row exactly as it was before this change. It is
+ * dead weight for the app itself and exists only so /more/leaderboard-row-benchmark
+ * can measure the two against each other on a real device.
+ *
+ * `LeaderboardRow` is what the leaderboard screen renders. Same pixels, but it
+ * calls no hooks at all: everything the row used to look up per instance —
+ * translations, the theme, the country check, the window width — is now hoisted
+ * to the screen and handed down. At 50 rows per commit that is the whole cost.
+ */
+
+// ---------------------------------------------------------------------------
+// Legacy row (baseline for the benchmark page)
+// ---------------------------------------------------------------------------
+
+export interface LeaderboardRowLegacyProps {
+    player?: ILeaderboardPlayer;
+    i: number;
+    leaderboardCountry: string | null;
+    authProfileId?: number | null;
+    rankWidth?: number;
+    myRankWidth?: number;
+    onSelect: (player: ILeaderboardPlayer) => void;
+}
+
+function LeaderboardRowLegacyInner(props: LeaderboardRowLegacyProps) {
+    const getTranslation = useTranslation();
+    const { player, i, rankWidth, myRankWidth, onSelect, leaderboardCountry, authProfileId } = props;
+
+    const styles = useLegacyStyles();
+
+    const isMe = player?.profileId != null && player?.profileId === authProfileId;
+    const rowStyle = { height: ROW_HEIGHT };
+    const weightStyle = { fontWeight: isMe ? 'bold' : 'normal' } as TextStyle;
+    const rankWidthStyle = { width: Math.max(myRankWidth || 43, rankWidth || 43) } as TextStyle;
+
+    return (
+        <TouchableOpacity style={[styles.row, rowStyle]} disabled={player == null} onPress={() => onSelect(player!)}>
+            <View style={styles.innerRowWithBorder}>
+                <TextLoader numberOfLines={1} style={[styles.cellRank, weightStyle, rankWidthStyle]}>
+                    #{isCountry(leaderboardCountry) ? player?.rankCountry : player?.rank || i + 1}
+                </TextLoader>
+
+                <TextLoader style={isMe ? styles.cellRatingMe : styles.cellRating}>{player?.rating}</TextLoader>
+                <View style={styles.cellName}>
+                    <ImageLoader source={{ uri: player?.avatarSmallUrl }} ready={player} className="w-5 h-5 mr-2 rounded-full" />
+                    <TextLoader style={isMe ? styles.nameMe : styles.name} numberOfLines={1}>
+                        {player?.name}
+                    </TextLoader>
+                </View>
+
+                {Dimensions.get('window').width >= 360 && (
+                    <TextLoader ready={player?.games} style={styles.cellGames}>
+                        {getTranslation('leaderboard.games', { games: player?.games })}
+                    </TextLoader>
+                )}
+            </View>
+        </TouchableOpacity>
+    );
+}
+
+export const LeaderboardRowLegacy = React.memo(LeaderboardRowLegacyInner);
+
+// ---------------------------------------------------------------------------
+// Current row
+// ---------------------------------------------------------------------------
+
+export interface LeaderboardRowProps {
+    /** Undefined while the page this row belongs to has not landed yet. */
+    player?: ILeaderboardPlayer;
+    i: number;
+    /**
+     * `isCountry(leaderboardCountry)` from the screen. isCountry() lowercases and
+     * then scans a ~250-entry array, which has no business running once per row.
+     */
+    showCountryRank: boolean;
+    /** `Dimensions.get('window').width >= 360` from the screen. */
+    showGames: boolean;
+    /** The raw `leaderboard.games` string, still holding its `{games}` placeholder. */
+    gamesLabel: string;
+    authProfileId?: number | null;
+    /** Already resolved to `Math.max(myRankWidth || 43, rankWidth || 43)`. */
+    rankWidth: number;
+    /**
+     * Handed down rather than looked up here. createStylesheet() builds both theme
+     * variants once at module load, so the object identity is stable per theme and
+     * this stays memo-safe — but calling the hook per row would mean one
+     * useColorScheme subscription per row, plus another for every text inside it.
+     */
+    styles: LeaderboardRowStyles;
+    onSelect: (player: ILeaderboardPlayer) => void;
+}
+
+// Constant across themes, so they can live outside the themed sheet and be
+// referenced without allocating a style array per render.
+const staticStyles = StyleSheet.create({
+    row: {
+        flex: 1,
+        height: ROW_HEIGHT,
+    },
+    rowPressed: {
+        flex: 1,
+        height: ROW_HEIGHT,
+        opacity: 0.2,
+    },
+});
+
+// Module-level, so Pressable gets the same function identity on every render.
+// Matches TouchableOpacity's press feedback.
+const pressableStyle = ({ pressed }: PressableStateCallbackType) => (pressed ? staticStyles.rowPressed : staticStyles.row);
+
+function LeaderboardRowInner(props: LeaderboardRowProps) {
+    const { player, i, showCountryRank, showGames, gamesLabel, authProfileId, rankWidth, styles, onSelect } = props;
+
+    const isMe = player?.profileId != null && player.profileId === authProfileId;
+    const rankWidthStyle = { width: rankWidth };
+
+    return (
+        <Pressable style={player == null ? staticStyles.row : pressableStyle} disabled={player == null} onPress={() => onSelect(player!)}>
+            <View style={styles.innerRowWithBorder}>
+                {/*
+                 * No skeleton here, deliberately: the old row passed `#` plus the
+                 * value to TextLoader, i.e. children were an array and never null,
+                 * so the rank cell always rendered — falling back to the list index
+                 * while the page was still in flight. Keep that; a column of #1..#50
+                 * during loading is the only thing telling you where you are.
+                 */}
+                <Text numberOfLines={1} style={[isMe ? styles.cellRankMe : styles.cellRank, rankWidthStyle]}>
+                    #{showCountryRank ? player?.rankCountry : player?.rank || i + 1}
+                </Text>
+
+                {player == null ? (
+                    <Text style={styles.cellRatingSkeleton} />
+                ) : (
+                    <Text style={isMe ? styles.cellRatingMe : styles.cellRating}>{player.rating}</Text>
+                )}
+
+                <View style={styles.cellName}>
+                    <View style={player == null ? styles.avatarSkeleton : styles.avatar}>
+                        {!!player?.avatarSmallUrl && <Image source={{ uri: player.avatarSmallUrl }} style={styles.avatarImage} />}
+                    </View>
+                    {player == null ? (
+                        <Text style={styles.nameSkeleton} />
+                    ) : (
+                        <Text style={isMe ? styles.nameMe : styles.name} numberOfLines={1}>
+                            {player.name}
+                        </Text>
+                    )}
+                </View>
+
+                {!!showGames &&
+                    (player?.games ? (
+                        // The placeholder is always literally `{games}` in every
+                        // translation, so a plain replace saves building a RegExp
+                        // per row the way getTranslation() does.
+                        <Text style={styles.cellGames}>{gamesLabel.replace('{games}', String(player.games))}</Text>
+                    ) : (
+                        <Text style={styles.cellGamesSkeleton} />
+                    ))}
+            </View>
+        </Pressable>
+    );
+}
+
+export const LeaderboardRow = React.memo(LeaderboardRowInner);
+
+/**
+ * Reads the raw `leaderboard.games` string (placeholder intact) so the row can
+ * fill it in without a translation lookup of its own.
+ */
+export function useLeaderboardGamesLabel() {
+    const getTranslation = useTranslation();
+    return getTranslation('leaderboard.games') ?? '';
+}
+
+const padding = 8;
+
+// Only the styles a row actually uses. Text colours and sizes are baked in here
+// because the row renders plain react-native <Text>, not MyText — MyText applies
+// them by calling useAppTheme(), i.e. one more useColorScheme subscription per
+// cell, four cells per row, fifty rows per commit.
+export const useLeaderboardRowStyles = createStylesheet((theme) => {
+    const skeleton = {
+        backgroundColor: theme.skeletonColor,
+        borderRadius: 5,
+        color: 'transparent',
+    } as const;
+    // Matches the height react-native gives a single line of text at these sizes,
+    // so the bar sits where the text will. An empty <Text> keeps the element type
+    // stable across the skeleton -> data swap (React updates props instead of
+    // tearing the native view down) and costs no text measuring in the meantime.
+    const skeletonLine = { ...skeleton, height: 17 };
+    const skeletonLineSmall = { ...skeleton, height: 15 };
+
+    const cellRank = {
+        margin: padding,
+        textAlign: 'left',
+        fontSize: 14,
+        color: theme.textColor,
+    } as const;
+    const cellRating = {
+        margin: padding,
+        width: 38,
+        fontSize: 14,
+        color: theme.textColor,
+    } as const;
+    const name = {
+        flex: 1,
+        fontSize: 14,
+        color: theme.textColor,
+    } as const;
+    const cellGames = {
+        margin: padding,
+        width: 90,
+        textAlign: 'right',
+        fontSize: 12,
+        color: theme.textNoteColor,
+    } as const;
+    const avatar = {
+        width: 20,
+        height: 20,
+        marginRight: 8,
+        borderRadius: 10,
+    } as const;
+
+    return StyleSheet.create({
+        innerRowWithBorder: {
+            flex: 1,
+            width: '100%',
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: 15,
+            borderBottomWidth: 1,
+            borderBottomColor: theme.lightBorderColor,
+        },
+        cellRank,
+        cellRankMe: { ...cellRank, fontWeight: 'bold' },
+        cellRating,
+        cellRatingMe: { ...cellRating, fontWeight: 'bold' },
+        cellRatingSkeleton: { ...cellRating, ...skeletonLine },
+        cellName: {
+            margin: padding,
+            flex: 4,
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+        name,
+        nameMe: { ...name, fontWeight: 'bold' },
+        nameSkeleton: { ...name, ...skeletonLine },
+        cellGames,
+        cellGamesSkeleton: { ...cellGames, ...skeletonLineSmall },
+        avatar,
+        avatarSkeleton: { ...avatar, backgroundColor: theme.skeletonColor },
+        avatarImage: { width: 20, height: 20, borderRadius: 10 },
+    } as const);
+});
+
+export type LeaderboardRowStyles = ReturnType<typeof useLeaderboardRowStyles>;
+
+const useLegacyStyles = createStylesheet((theme) =>
+    StyleSheet.create({
+        name: {
+            flex: 1,
+        },
+        nameMe: {
+            flex: 1,
+            fontWeight: 'bold',
+        },
+        cellRank: {
+            margin: padding,
+            textAlign: 'left',
+        },
+        cellRating: {
+            margin: padding,
+            width: 38,
+        },
+        cellRatingMe: {
+            margin: padding,
+            width: 38,
+            fontWeight: 'bold',
+        },
+        cellName: {
+            margin: padding,
+            flex: 4,
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+        cellGames: {
+            margin: padding,
+            width: 90,
+            textAlign: 'right',
+            fontSize: 12,
+            color: theme.textNoteColor,
+        },
+        row: {
+            flex: 1,
+        },
+        innerRowWithBorder: {
+            flex: 1,
+            width: '100%',
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: 15,
+            borderBottomWidth: 1,
+            borderBottomColor: theme.lightBorderColor,
+        },
+    } as const)
+);


### PR DESCRIPTION
The leaderboard's cost is the row: a commit there is rows-rendered x per-row cost, and the commit that hurts is the one where a page lands and fifty skeleton rows turn into fifty rows with data. There was no way to measure that in isolation, so this adds one and then acts on it.

## 1. New page: More → "Leaderboard row benchmark"

`src/app/(main)/statistics/leaderboard-row-benchmark.tsx`

Fifty rows, no network, no virtualization in the way, and a button that flips them skeleton → data while timing the transition. **Show data (measure)** does one run by hand so the change can be watched on-device; **Run 10x** / **Run 30x** collect a distribution. Per run it reports:

| | |
|---|---|
| `js` | state flip → `useLayoutEffect` after the commit carrying the data, i.e. the React render + commit that blocks the JS thread |
| `frame` | the same start → second rAF after that commit, so it also covers native layout and getting the frame out |
| `react` | `<Profiler>` actualDuration for the row subtree (dev builds only — React does not call `onRender` in release) |

Shown live in the UI as the last run plus n/mean/median/p95/min/max, and a legacy-vs-current median line. Both row versions are selectable so the two can be measured back to back on the same device; `components/leaderboard/leaderboard-row.tsx` keeps the old row as `LeaderboardRowLegacy` purely as that baseline. Avatars are a 1x1 data URI so an `<Image>` still mounts and decodes per row without dragging network latency into every run.

## 2. The row itself now calls zero hooks

Per row, the old one called: `useTranslation` (three `useQuery` subscriptions plus a `useMMKVString`), `useStyles` (`useColorScheme`), and then one more `useStyles` plus MyText's `useAppTheme` inside every `TextLoader` — about thirteen subscriptions per row, three of them react-query observers, times fifty rows per commit. It also ran `isCountry()` (lowercase + scan of ~250 countries) and `Dimensions.get()` per row per render.

All of it is hoisted to the screen and passed down: the resolved stylesheet (`createStylesheet` builds both theme variants once at module load, so the identity is stable and `React.memo` still holds), the `{games}` label with its placeholder intact, `showCountryRank`, `showGames`, and the already-maxed rank width. Alongside that:

- plain react-native `<Text>` with colours baked into the sheet, instead of MyText/TextLoader
- the skeleton is an empty `<Text>` with an explicit height rather than 45 braille-blank characters, so there is nothing to measure, and the element type stays the same across the swap — React updates props instead of tearing down and rebuilding the native views
- `Pressable` instead of `TouchableOpacity` (no `Animated.Value` + animated style node per row), same 0.2 press opacity
- the avatar placeholder is a rounded `View`, not a `View` wrapping a `Text` of 36 dots

Pixels are unchanged. That includes one thing that reads like a bug and is not: the rank cell never showed a skeleton, because its children were an array and so never null, which is what puts #1..#50 on screen while a page is in flight. Kept.

## Verification

biome lint clean, and `react-compiler-report` compiles all of `LeaderboardPage`, `LeaderboardRowInner`, `LeaderboardRowLegacyInner` and the four benchmark-page components — no new bailouts.

Two caveats worth knowing before reading any numbers off the page:

- Dependencies could not be installed in the session that wrote this (`FONTAWESOME_NPM_AUTH_TOKEN` was not available), so **nothing was run on a device or simulator**. biome and the compiler report were run from standalone copies of those tools.
- The empty-`<Text>`-with-explicit-height skeleton is a standard RN placeholder, but it is the one thing worth eyeballing first on device — if a bar renders collapsed, swapping those to `<View>` is a one-line change per cell.

The bench link sits in the More list unconditionally, so it ships to users as-is. Wrap that one entry in `__DEV__` if it should not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MKQgGLp1x8741CiwAGKoU

---
_Generated by [Claude Code](https://claude.ai/code/session_016MKQgGLp1x8741CiwAGKoU)_